### PR TITLE
Add dependencies needed for Java 10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     compile 'com.sun.xml.bind:jaxb-core:2.2.11'
     compile 'com.sun.xml.bind:jaxb-impl:2.2.11'
     compile 'com.sun.xml.bind:jaxb-xjc:2.2.11'
+    compile 'javax.xml.bind:jaxb-api:2.2.11'
+    compile 'javax.activation:activation:1.1.1'
     compile 'xml-resolver:xml-resolver:1.2'
 
     testCompile('org.spockframework:spock-core:1.1-groovy-2.4') {


### PR DESCRIPTION
Hello,

I'm using Java 10.0.2 and the plugin is failing with the following error:
```
Caused by: java.util.ServiceConfigurationError: com.sun.tools.xjc.Plugin: com.sun.tools.xjc.addon.accessors.PluginImpl Unable to get public no-arg constructor
...
Caused by: java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlAccessType
```

I added these two dependencies and it seems to work correctly. It should not break the compatibility with Java 8.

Thanks :)