### PR TITLE
Support for non-local schema (mainly WSDL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ Additionally, the following parameter may be used to control the output code gen
 
 ### Remote schemas
 If the schema can or should not be located in the local file system, place a file with the extension `.url` into
-`src/main/schema` which contains the URL of the remote schema (a WSDL for example). Configure the plugin to 
-match for `.url` files.
+`src/main/schema` which contains the URL of the remote schema (a WSDL for example).
 
 Multiple URLs can be placed into one file, one URL per line. Alternativly multiple files with one line each can be used.
 
@@ -112,7 +111,7 @@ https://www.domain.com/service?WSDL
 
 ```groovy
 xjcGenerate {
-    source = fileTree('src/main/schema') { include '*.url' }
+    urlSources = fileTree('src/main/schema') { include '*.url' }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Multiple URLs can be placed into one file, one URL per line. Alternativly multip
 #### Example
 
 ```text
+# remote.url
 https://www.domain.com/service?WSDL
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,25 @@ Additionally, the following parameter may be used to control the output code gen
 | `encoding` | `String` | Encoding for generated Java files | `UTF-8` |
 | `docLanguage` | `String` | Desired language for Javadoc comments in generated code (e.g. `"en-US"`) | JVM's default `Locale` |
 
+### Remote schemas
+If the schema can or should not be located in the local file system, place a file with the extension `.url` into
+`src/main/schema` which contains the URL of the remote schema (a WSDL for example). Configure the plugin to 
+match for `.url` files.
+
+Multiple URLs can be placed into one file, one URL per line. Alternativly multiple files with one line each can be used.
+
+#### Example
+
+```text
+https://www.domain.com/service?WSDL
+```
+
+```groovy
+xjcGenerate {
+    source = fileTree('src/main/schema') { include '*.url' }
+}
+```
+
 
 ## Including Generated Code in the Compilation
 

--- a/src/integration-test/groovy/org/unbrokendome/gradle/plugins/xjc/XjcIntegrationTest.groovy
+++ b/src/integration-test/groovy/org/unbrokendome/gradle/plugins/xjc/XjcIntegrationTest.groovy
@@ -66,7 +66,9 @@ class XjcIntegrationTest extends Specification {
     def "build remote wsdl"() {
         given:
             def schemaFolder = testProjectDir.newFolder('src', 'main', 'schema')
-           
+            File urlFile = testProjectDir.newFile('src/main/schema/vat.url')
+            urlFile << "http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl"
+
             buildFile << """
                 plugins {
                     id 'org.unbroken-dome.xjc'
@@ -77,8 +79,7 @@ class XjcIntegrationTest extends Specification {
                 }
             """
         when:
-            File urlFile = testProjectDir.newFile('src/main/schema/vat.url')
-            urlFile << "http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl"
+
             def result = GradleRunner.create()
                     .withProjectDir(testProjectDir.root)
                     .withPluginClasspath()
@@ -86,7 +87,6 @@ class XjcIntegrationTest extends Specification {
                     .withDebug(true)
                     .build()
             def generatedFiles = new File(testProjectDir.root, 'build/xjc/generated-sources').listFiles()*.name
-            println generatedFiles
         then:
             result.task(':xjcGenerate').outcome == TaskOutcome.SUCCESS
         and:
@@ -98,7 +98,7 @@ class XjcIntegrationTest extends Specification {
             def schemaFolder = testProjectDir.newFolder('src', 'main', 'schema')
             File urlFile = testProjectDir.newFile('src/main/schema/vat.url')
             urlFile << "\\ec.europa.eu/taxation_customs/vies/checkVatService.wsdl"
-            
+
             buildFile << """
                 plugins {
                     id 'org.unbroken-dome.xjc'

--- a/src/integration-test/groovy/org/unbrokendome/gradle/plugins/xjc/XjcIntegrationTest.groovy
+++ b/src/integration-test/groovy/org/unbrokendome/gradle/plugins/xjc/XjcIntegrationTest.groovy
@@ -1,7 +1,11 @@
 package org.unbrokendome.gradle.plugins.xjc
 
+import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.gradle.testkit.runner.UnexpectedBuildResultException
+import org.gradle.testkit.runner.UnexpectedBuildSuccess
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
@@ -56,5 +60,64 @@ class XjcIntegrationTest extends Specification {
                     'USAddress.java',
                     'Items.java',
                     'ObjectFactory.java')
+    }
+    
+    
+    def "build remote wsdl"() {
+        given:
+            def schemaFolder = testProjectDir.newFolder('src', 'main', 'schema')
+           
+            buildFile << """
+                plugins {
+                    id 'org.unbroken-dome.xjc'
+                }
+
+                xjcGenerate {
+                    source = fileTree('src/main/schema') { include '*.url' }
+                }
+            """
+        when:
+            File urlFile = testProjectDir.newFile('src/main/schema/vat.url')
+            urlFile << "http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl"
+            def result = GradleRunner.create()
+                    .withProjectDir(testProjectDir.root)
+                    .withPluginClasspath()
+                    .withArguments('xjcGenerate', '--stacktrace')
+                    .withDebug(true)
+                    .build()
+            def generatedFiles = new File(testProjectDir.root, 'build/xjc/generated-sources').listFiles()*.name
+            println generatedFiles
+        then:
+            result.task(':xjcGenerate').outcome == TaskOutcome.SUCCESS
+        and:
+            expect generatedFiles, contains('eu')
+    }
+    
+    def "broken url"() {
+        given:
+            def schemaFolder = testProjectDir.newFolder('src', 'main', 'schema')
+            File urlFile = testProjectDir.newFile('src/main/schema/vat.url')
+            urlFile << "\\ec.europa.eu/taxation_customs/vies/checkVatService.wsdl"
+            
+            buildFile << """
+                plugins {
+                    id 'org.unbroken-dome.xjc'
+                }
+
+                xjcGenerate {
+                    source = fileTree('src/main/schema') { include '*.url' }
+                }
+            """
+        when:
+            def result = GradleRunner.create()
+                    .withProjectDir(testProjectDir.root)
+                    .withPluginClasspath()
+                    .withArguments('xjcGenerate', '--stacktrace')
+                    .withDebug(true)
+                    .buildAndFail()
+        then:
+            notThrown UnexpectedBuildSuccess
+            result.task(':xjcGenerate').outcome == TaskOutcome.FAILED
+            
     }
 }

--- a/src/integration-test/groovy/org/unbrokendome/gradle/plugins/xjc/XjcIntegrationTest.groovy
+++ b/src/integration-test/groovy/org/unbrokendome/gradle/plugins/xjc/XjcIntegrationTest.groovy
@@ -1,19 +1,17 @@
 package org.unbrokendome.gradle.plugins.xjc
 
-import org.gradle.api.tasks.TaskExecutionException
-import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome
-import org.gradle.testkit.runner.UnexpectedBuildFailure
-import org.gradle.testkit.runner.UnexpectedBuildResultException
-import org.gradle.testkit.runner.UnexpectedBuildSuccess
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
+import static org.hamcrest.Matchers.*
+import static spock.util.matcher.HamcrestSupport.*
 
 import java.nio.file.Files
 
-import static spock.util.matcher.HamcrestSupport.*
-import static org.hamcrest.Matchers.*
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildSuccess
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+import spock.lang.Specification
 
 
 class XjcIntegrationTest extends Specification {
@@ -74,9 +72,6 @@ class XjcIntegrationTest extends Specification {
                     id 'org.unbroken-dome.xjc'
                 }
 
-                xjcGenerate {
-                    source = fileTree('src/main/schema') { include '*.url' }
-                }
             """
         when:
 
@@ -92,7 +87,7 @@ class XjcIntegrationTest extends Specification {
         and:
             expect generatedFiles, contains('eu')
     }
-    
+
     def "broken url"() {
         given:
             def schemaFolder = testProjectDir.newFolder('src', 'main', 'schema')
@@ -118,6 +113,6 @@ class XjcIntegrationTest extends Specification {
         then:
             notThrown UnexpectedBuildSuccess
             result.task(':xjcGenerate').outcome == TaskOutcome.FAILED
-            
+            result.output.contains('java.net.MalformedURLException')
     }
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.groovy
@@ -1,11 +1,7 @@
 package org.unbrokendome.gradle.plugins.xjc
 
-import com.sun.codemodel.JCodeModel
-import com.sun.tools.xjc.Language
-import com.sun.tools.xjc.ModelLoader
-import com.sun.tools.xjc.Options
-import com.sun.tools.xjc.api.SpecVersion
-import com.sun.tools.xjc.util.ErrorReceiverFilter
+import java.util.regex.Pattern
+
 import org.apache.xml.resolver.CatalogManager
 import org.apache.xml.resolver.tools.CatalogResolver
 import org.gradle.api.artifacts.Configuration
@@ -14,8 +10,13 @@ import org.gradle.api.tasks.*
 import org.unbrokendome.gradle.plugins.xjc.resolver.ClasspathUriResolver
 import org.unbrokendome.gradle.plugins.xjc.resolver.ExtensibleCatalogResolver
 import org.unbrokendome.gradle.plugins.xjc.resolver.MavenUriResolver
+import org.xml.sax.InputSource
 
-import java.util.regex.Pattern
+import com.sun.codemodel.JCodeModel
+import com.sun.tools.xjc.ModelLoader
+import com.sun.tools.xjc.Options
+import com.sun.tools.xjc.api.SpecVersion
+import com.sun.tools.xjc.util.ErrorReceiverFilter
 
 
 class XjcGenerate extends SourceTask {
@@ -183,7 +184,7 @@ class XjcGenerate extends SourceTask {
 
         def options = new Options()
 
-        options.schemaLanguage = Language.XMLSCHEMA
+        //options.schemaLanguage = Language.XMLSCHEMA
         options.target = (targetVersion != null) ? SpecVersion.parse(targetVersion) : SpecVersion.LATEST
         options.targetDir = getOutputDirectory()
 
@@ -195,7 +196,20 @@ class XjcGenerate extends SourceTask {
             options.entityResolver = catalogResolver
         }
 
-        source?.each { options.addGrammar it }
+        source?.each {
+             if (it.name.endsWith('.url')) {
+                 it.readLines().grep { line -> line?.trim() }.each { url -> 
+                     try {
+                         url.toURL().toURI()
+                     } catch(MalformedURLException | URISyntaxException e) {
+                         throw new IllegalArgumentException(e)
+                     }
+                     options.addGrammar(new InputSource(url)) 
+                 }    
+             } else {
+                 options.addGrammar it
+             }
+        }
         bindingFiles?.each { options.addBindFile it }
         pluginClasspath?.each { options.classpaths.add it.toURI().toURL() }
         episodes?.each { options.scanEpisodeFile it }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.groovy
@@ -184,7 +184,6 @@ class XjcGenerate extends SourceTask {
 
         def options = new Options()
 
-        //options.schemaLanguage = Language.XMLSCHEMA
         options.target = (targetVersion != null) ? SpecVersion.parse(targetVersion) : SpecVersion.LATEST
         options.targetDir = getOutputDirectory()
 

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.groovy
@@ -36,6 +36,7 @@ class XjcPlugin implements Plugin<Project> {
         xjcTask.description = 'Generates Java classes from XML schema using the XJC binding compiler'
         xjcTask.source = project.fileTree('src/main/schema') { include '*.xsd' }
         xjcTask.bindingFiles = project.fileTree('src/main/schema') { include '*.xjb' }
+        xjcTask.urlSources  = project.fileTree('src/main/schema') { include '*.url' }
         xjcTask.episodes = project.configurations.create XJC_EPISODE_CONFIGURATION_NAME
         xjcTask.pluginClasspath = project.configurations.create XJC_CLASSPATH_CONFIGURATION_NAME
         xjcTask.conventionMapping.with {


### PR DESCRIPTION
Although XJC actually accepts remote URLS as input source for schemas, this is currently not supported by the plugin. This should be a minimal invasive patch to enable that for the plugin as well.