### PR TITLE
Support jaxb 2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,10 @@ repositories {
 
 
 dependencies {
-    compile 'com.sun.xml.bind:jaxb-core:2.3.0.1'
-    compile 'com.sun.xml.bind:jaxb-impl:2.3.1'
-    compile 'com.sun.xml.bind:jaxb-xjc:2.3.1'
-    compile 'javax.xml.bind:jaxb-api:2.3.1'
+    compile 'com.sun.xml.bind:jaxb-core:2.2.11'
+    compile 'com.sun.xml.bind:jaxb-impl:2.2.11'
+    compile 'com.sun.xml.bind:jaxb-xjc:2.2.11'
+    compile 'javax.xml.bind:jaxb-api:2.2.11'
     compile 'javax.activation:activation:1.1.1'
     compile 'xml-resolver:xml-resolver:1.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,10 @@ repositories {
 
 
 dependencies {
-    compile 'com.sun.xml.bind:jaxb-core:2.2.11'
-    compile 'com.sun.xml.bind:jaxb-impl:2.2.11'
-    compile 'com.sun.xml.bind:jaxb-xjc:2.2.11'
-    compile 'javax.xml.bind:jaxb-api:2.2.11'
+    compile 'com.sun.xml.bind:jaxb-core:2.3.0.1'
+    compile 'com.sun.xml.bind:jaxb-impl:2.3.1'
+    compile 'com.sun.xml.bind:jaxb-xjc:2.3.1'
+    compile 'javax.xml.bind:jaxb-api:2.3.1'
     compile 'javax.activation:activation:1.1.1'
     compile 'xml-resolver:xml-resolver:1.2'
 

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.groovy
@@ -215,6 +215,9 @@ class XjcGenerate extends SourceTask {
         }
         bindingFiles?.each { options.addBindFile it }
         pluginClasspath?.each { options.classpaths.add it.toURI().toURL() }
+
+        Thread.currentThread().setContextClassLoader(options.getUserClassLoader(Thread.currentThread().getContextClassLoader()))
+
         episodes?.each { options.scanEpisodeFile it }
 
         options.strictCheck = strictCheck

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.groovy
@@ -1,5 +1,7 @@
 package org.unbrokendome.gradle.plugins.xjc
 
+import org.gradle.util.VersionNumber
+
 import java.util.regex.Pattern
 
 import org.apache.xml.resolver.CatalogManager
@@ -53,6 +55,10 @@ class XjcGenerate extends SourceTask {
     @Input
     @Optional
     String targetVersion
+
+    @Input
+    String jaxbVersion = "2.2.11"
+
     @Input
     boolean extension = false
     @Input
@@ -216,7 +222,11 @@ class XjcGenerate extends SourceTask {
         bindingFiles?.each { options.addBindFile it }
         pluginClasspath?.each { options.classpaths.add it.toURI().toURL() }
 
-        Thread.currentThread().setContextClassLoader(options.getUserClassLoader(Thread.currentThread().getContextClassLoader()))
+        // Handles adding the plugins into the TCCL classpath that the Options class no longer does
+        VersionNumber jaxbVersionNumber = VersionNumber.parse(jaxbVersion)
+        if (jaxbVersionNumber.major == 2 && jaxbVersionNumber.minor > 2) {
+            Thread.currentThread().setContextClassLoader(options.getUserClassLoader(Thread.currentThread().getContextClassLoader()))
+        }
 
         episodes?.each { options.scanEpisodeFile it }
 


### PR DESCRIPTION
Currently upgrades to jaxb 2.3 explicity, this is probably required to be configurable and I might need some help with that to get it going.

Fixes the jaxb 2.3 issue with the Options class not taking the classpath variable into account when loading using the TCCL classloader.

Fixes #13 