### PR TITLE
Support for JakartaEE JAXB/XJC 4.0 + major dependency upgrades

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,8 +21,8 @@ Invokes the `xjc` binding compiler from a Gradle build.
 
 == Requirements
 
-- Gradle 5.6 or higher
-- JDK 1.8 or higher (when running Gradle)
+- Gradle 6.8 or higher
+- JDK 11 or higher (when running Gradle)
 
 
 == Quick Start
@@ -34,7 +34,7 @@ dependency on the JAXB API:
 .build.gradle(.kts)
 ----
 plugins {
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "3.0.0"
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,10 +2,10 @@ plugins {
     kotlin("jvm")
     `java-gradle-plugin`
     `maven-publish`
-    id("org.unbroken-dome.test-sets") version "3.0.1"
-    id("com.gradle.plugin-publish") version "0.12.0"
-    id("org.asciidoctor.convert") version "1.5.9.2"
-    id("org.jetbrains.dokka") version "0.10.1"
+    id("org.unbroken-dome.test-sets") version "4.0.0"
+    id("com.gradle.plugin-publish") version "1.1.0"
+    id("org.asciidoctor.jvm.convert") version "3.3.2"
+    id("org.jetbrains.dokka") version "1.8.10"
 }
 
 
@@ -13,7 +13,7 @@ val kotlinVersion: String by extra
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 
@@ -34,20 +34,30 @@ val xjcCommon: SourceSet by sourceSets.creating
 val xjc22: SourceSet by sourceSets.creating
 val xjc23: SourceSet by sourceSets.creating
 val xjc30: SourceSet by sourceSets.creating
-val xjcSourceSets = listOf(xjcCommon, xjc22, xjc23, xjc30)
+val xjc40: SourceSet by sourceSets.creating
+val xjcSourceSets = listOf(xjcCommon, xjc22, xjc23, xjc30, xjc40)
 
+val asciidoctorExtensions by configurations.creating
+
+configurations {
+    xjcSourceSets.forEach { xjcSourceSet ->
+        (xjcSourceSet.compileOnlyConfigurationName) {
+            extendsFrom(configurations["compileOnly"], configurations["implementation"])
+        }
+    }
+}
 
 dependencies {
+    asciidoctorExtensions("com.bmuschko:asciidoctorj-tabbed-code-extension:0.3")
+
     compileOnly(kotlin("stdlib-jdk8"))
     compileOnly(gradleApi())
 
     implementation("javax.activation:javax.activation-api:1.2.0")
     implementation("xml-resolver:xml-resolver:1.2")
 
-    for (xjcSourceSet in xjcSourceSets) {
+    xjcSourceSets.forEach { xjcSourceSet ->
         (xjcSourceSet.compileOnlyConfigurationName)(sourceSets["main"].output)
-        (xjcSourceSet.compileOnlyConfigurationName)(configurations["compileOnly"])
-        (xjcSourceSet.implementationConfigurationName)(configurations["implementation"])
     }
 
     "xjcCommonCompileOnly"("com.sun.xml.bind:jaxb-xjc:2.3.3")
@@ -62,21 +72,25 @@ dependencies {
     "xjc23CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.3.3")
 
     "xjc30CompileOnly"(xjcCommon.output)
-    "xjc30CompileOnly"("com.sun.xml.bind:jaxb-xjc:3.0.0-M4")
+    "xjc30CompileOnly"("com.sun.xml.bind:jaxb-xjc:3.0.0")
     "xjc30CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.3.3")
-    "xjc30CompileOnly"("jakarta.xml.bind:jakarta.xml.bind-api:3.0.0-RC3")
+    "xjc30CompileOnly"("jakarta.xml.bind:jakarta.xml.bind-api:3.0.0")
+
+    "xjc40CompileOnly"(xjcCommon.output)
+    "xjc40CompileOnly"("com.sun.xml.bind:jaxb-xjc:4.0.2")
+    "xjc40CompileOnly"("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
 
     "testLibApi"(kotlin("stdlib-jdk8"))
-    "testLibApi"("com.willowtreeapps.assertk:assertk-jvm:0.22")
+    "testLibApi"("com.willowtreeapps.assertk:assertk-jvm:0.25")
 
-    "testImplementation"("org.spekframework.spek2:spek-dsl-jvm:2.0.9")
-    "testRuntimeOnly"("org.spekframework.spek2:spek-runner-junit5:2.0.9")
+    "testImplementation"("org.spekframework.spek2:spek-dsl-jvm:2.0.19")
+    "testRuntimeOnly"("org.spekframework.spek2:spek-runner-junit5:2.0.19")
 
     "integrationTestImplementation"(gradleTestKit())
-    "integrationTestImplementation"("org.junit.jupiter:junit-jupiter-api:5.7.0")
-    "integrationTestImplementation"("org.junit.platform:junit-platform-commons:1.7.0")
-    "integrationTestImplementation"("org.ow2.asm:asm:9.0")
-    "integrationTestRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine:5.7.0")
+    "integrationTestImplementation"("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    "integrationTestImplementation"("org.junit.platform:junit-platform-commons:1.9.1")
+    "integrationTestImplementation"("org.ow2.asm:asm:9.4")
+    "integrationTestRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 }
 
 
@@ -88,9 +102,15 @@ configurations.all {
     }
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
     kotlinOptions.freeCompilerArgs = listOf("-Xjvm-default=enable")
 }
 
@@ -174,52 +194,43 @@ gradlePlugin {
 }
 
 
-pluginBundle {
-    website = "https://github.com/unbroken-dome/gradle-xjc-plugin"
-    vcsUrl = "https://github.com/unbroken-dome/gradle-xjc-plugin"
-    description = "A plugin that integrates the XJC binding compiler into a Gradle build."
-    tags = listOf("xjc", "jaxb", "code generation", "xml")
+gradlePlugin {
+    website.set("https://github.com/unbroken-dome/gradle-xjc-plugin")
+    vcsUrl.set("https://github.com/unbroken-dome/gradle-xjc-plugin")
 
     (plugins) {
         "xjcPlugin" {
             displayName = "XJC Plugin"
+            description = "A plugin that integrates the XJC binding compiler into a Gradle build."
+            tags.set(listOf("xjc", "jaxb", "code generation", "xml"))
         }
     }
 }
 
 
-tasks.named("dokka", org.jetbrains.dokka.gradle.DokkaTask::class) {
-    outputFormat = "html"
-    configuration {
-        externalDocumentationLink {
-            url = uri("https://docs.gradle.org/current/javadoc/").toURL()
-        }
-        reportUndocumented = false
-        sourceLink {
-            path = "src/main/kotlin"
-            url = "https://github.com/unbroken-dome/gradle-xjc-plugin/blob/v${project.version}/src/main/kotlin"
-            lineSuffix = "#L"
-        }
-        perPackageOption {
-            prefix = "org.unbrokendome.gradle.plugins.xjc.internal"
-            suppress = true
+tasks.withType(org.jetbrains.dokka.gradle.DokkaTask::class).configureEach {
+    dokkaSourceSets  {
+        configureEach {
+            externalDocumentationLink {
+                url.set(uri("https://docs.gradle.org/current/javadoc/").toURL())
+            }
+            reportUndocumented.set(false)
+            sourceLink {
+                localDirectory.set(file("src/main/kotlin"))
+                remoteUrl.set(uri("https://github.com/unbroken-dome/gradle-xjc-plugin/blob/v${project.version}/src/main/kotlin").toURL())
+                remoteLineSuffix.set("#L")
+            }
+            perPackageOption {
+                matchingRegex.set("""org\.unbrokendome\.gradle\.plugins\.xjc\.internal""")
+                suppress.set(true)
+            }
         }
     }
 }
 
-
-asciidoctorj {
-    version = "2.4.1"
-}
-
-dependencies {
-    "asciidoctor"("com.bmuschko:asciidoctorj-tabbed-code-extension:0.3")
-}
-
-
-tasks.named("asciidoctor", org.asciidoctor.gradle.AsciidoctorTask::class) {
-    sourceDir("docs")
-    sources(delegateClosureOf<PatternSet> { include("index.adoc") })
+tasks.named("asciidoctor", org.asciidoctor.gradle.jvm.AsciidoctorTask::class) {
+    setSourceDir(file("docs"))
+    baseDirFollowsSourceFile()
 
     options(mapOf(
         "doctype" to "book"

--- a/docs/prerequisites.adoc
+++ b/docs/prerequisites.adoc
@@ -2,6 +2,6 @@
 
 You need at least the following:
 
-* Gradle 5.6 or higher
+* Gradle 6.9 or higher
 
-* JDK 8 or higher (for running Gradle)
+* JDK 11 or higher (for running Gradle)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.3.72
+kotlinVersion=1.8.10
 
 group=org.unbroken-dome.gradle-plugins
-version=2.0.0
+version=3.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/groovy-dsl/basic/build.gradle
+++ b/samples/groovy-dsl/basic/build.gradle
@@ -1,11 +1,11 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '3.0.0'
 }
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/groovy-dsl/catalogs/build.gradle
+++ b/samples/groovy-dsl/catalogs/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/samples/groovy-dsl/catalogs/consumer/build.gradle
+++ b/samples/groovy-dsl/catalogs/consumer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '3.0.0'
 }
 
 

--- a/samples/groovy-dsl/complete/build.gradle
+++ b/samples/groovy-dsl/complete/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/samples/groovy-dsl/complete/consumer/build.gradle
+++ b/samples/groovy-dsl/complete/consumer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '3.0.0'
 }
 
 

--- a/samples/groovy-dsl/complete/library/build.gradle
+++ b/samples/groovy-dsl/complete/library/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java-library')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '3.0.0'
 }
 
 

--- a/samples/groovy-dsl/episodes/build.gradle
+++ b/samples/groovy-dsl/episodes/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/samples/groovy-dsl/episodes/episode-consumer/build.gradle
+++ b/samples/groovy-dsl/episodes/episode-consumer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '3.0.0'
 }
 
 

--- a/samples/groovy-dsl/episodes/episode-producer/build.gradle
+++ b/samples/groovy-dsl/episodes/episode-producer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java-library')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '3.0.0'
 }
 
 

--- a/samples/groovy-dsl/remote-schema/build.gradle
+++ b/samples/groovy-dsl/remote-schema/build.gradle
@@ -1,11 +1,11 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '3.0.0'
 }
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/groovy-dsl/xjc-plugin/build.gradle
+++ b/samples/groovy-dsl/xjc-plugin/build.gradle
@@ -1,11 +1,11 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '3.0.0'
 }
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/groovy-dsl/xjc-version-2_2/build.gradle
+++ b/samples/groovy-dsl/xjc-version-2_2/build.gradle
@@ -1,11 +1,11 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '3.0.0'
 }
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/groovy-dsl/xjc-version-4_0/build.gradle
+++ b/samples/groovy-dsl/xjc-version-4_0/build.gradle
@@ -10,11 +10,10 @@ repositories {
 
 
 xjc {
-    xjcVersion = '3.0'
+    xjcVersion = '4.0'
 }
-
 
 dependencies {
     // XJC 3.0 requires a different JAXB API artifact
-    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.0-RC3'
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
 }

--- a/samples/groovy-dsl/xjc-version-4_0/settings.gradle
+++ b/samples/groovy-dsl/xjc-version-4_0/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-version-4_0'

--- a/samples/groovy-dsl/xjc-version-4_0/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-version-4_0/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/basic/build.gradle.kts
+++ b/samples/kotlin-dsl/basic/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "3.0.0"
 }
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/kotlin-dsl/catalogs/build.gradle.kts
+++ b/samples/kotlin-dsl/catalogs/build.gradle.kts
@@ -1,5 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/samples/kotlin-dsl/catalogs/consumer/build.gradle.kts
+++ b/samples/kotlin-dsl/catalogs/consumer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "3.0.0"
 }
 
 

--- a/samples/kotlin-dsl/complete/build.gradle.kts
+++ b/samples/kotlin-dsl/complete/build.gradle.kts
@@ -1,5 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/samples/kotlin-dsl/complete/consumer/build.gradle.kts
+++ b/samples/kotlin-dsl/complete/consumer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "3.0.0"
 }
 
 

--- a/samples/kotlin-dsl/complete/library/build.gradle.kts
+++ b/samples/kotlin-dsl/complete/library/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `java-library`
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "3.0.0"
 }
 
 

--- a/samples/kotlin-dsl/episodes/build.gradle.kts
+++ b/samples/kotlin-dsl/episodes/build.gradle.kts
@@ -1,5 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/samples/kotlin-dsl/episodes/episode-consumer/build.gradle.kts
+++ b/samples/kotlin-dsl/episodes/episode-consumer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "3.0.0"
 }
 
 

--- a/samples/kotlin-dsl/episodes/episode-producer/build.gradle.kts
+++ b/samples/kotlin-dsl/episodes/episode-producer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `java-library`
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "3.0.0"
 }
 
 

--- a/samples/kotlin-dsl/remote-schema/build.gradle.kts
+++ b/samples/kotlin-dsl/remote-schema/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "3.0.0"
 }
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/kotlin-dsl/xjc-plugin/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-plugin/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "3.0.0"
 }
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-2_2/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_2/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "3.0.0"
 }
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-3_0/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-3_0/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "3.0.0"
 }
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-4_0/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-4_0/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "3.0.0"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("4.0")
+}
+
+dependencies {
+    // XJC 4.0 requires a different JAXB API artifact
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
+}

--- a/samples/kotlin-dsl/xjc-version-4_0/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-4_0/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-version-4_0"

--- a/samples/kotlin-dsl/xjc-version-4_0/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-version-4_0/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/GradleVersionCompatibilityIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/GradleVersionCompatibilityIntegrationTest.kt
@@ -17,7 +17,7 @@ import org.unbrokendome.gradle.plugins.xjc.testutil.runGradle
 import java.io.File
 
 
-const val AllGradleVersions = "6.6.1, 6.5.1, 6.4.1, 6.3, 6.2.2, 6.1.1, 6.0.1, 5.6.4, 5.6"
+const val AllGradleVersions = "8.0.2, 7.6.1, 7.5, 7.4.2, 7.3.3, 7.2, 7.1.1, 7.0.2, 6.9.4, 6.8.3"
 
 
 @GradleIntegrationTest

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPluginIntegrationTest.kt
@@ -2,17 +2,10 @@ package org.unbrokendome.gradle.plugins.xjc
 
 import assertk.all
 import assertk.assertThat
-import assertk.assertions.contains
 import assertk.assertions.containsAll
-import assertk.assertions.extracting
-import assertk.assertions.isFile
-import jdk.nashorn.internal.runtime.regexp.joni.constants.AsmConstants
+import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.platform.commons.annotation.Testable
-import org.objectweb.asm.ClassReader
-import org.objectweb.asm.ClassVisitor
-import org.objectweb.asm.MethodVisitor
-import org.objectweb.asm.Opcodes
 import org.unbrokendome.gradle.plugins.xjc.reflection.MethodInfo
 import org.unbrokendome.gradle.plugins.xjc.reflection.URLClassLoader
 import org.unbrokendome.gradle.plugins.xjc.reflection.loadClassInfo
@@ -25,8 +18,6 @@ import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.resolve
 import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.task
 import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.withJarFile
 import org.unbrokendome.gradle.plugins.xjc.testutil.runGradle
-import java.io.File
-import java.net.URLClassLoader
 
 
 @UseSampleProject("xjc-plugin")

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion40IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion40IntegrationTest.kt
@@ -1,0 +1,19 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("xjc-version-4_0")
+class XjcVersion40IntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "xjc-version-4_0")
+    }
+}

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.kt
@@ -43,7 +43,8 @@ abstract class XjcGenerate
         private val WorkActionClassNamesByVersion = mapOf(
             "2.2" to "org.unbrokendome.gradle.plugins.xjc.work.xjc22.XjcGeneratorWorkAction",
             "2.3" to "org.unbrokendome.gradle.plugins.xjc.work.xjc23.XjcGeneratorWorkAction",
-            "3.0" to "org.unbrokendome.gradle.plugins.xjc.work.xjc30.XjcGeneratorWorkAction"
+            "3.0" to "org.unbrokendome.gradle.plugins.xjc.work.xjc30.XjcGeneratorWorkAction",
+            "4.0" to "org.unbrokendome.gradle.plugins.xjc.work.xjc40.XjcGeneratorWorkAction"
         )
     }
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
@@ -8,7 +8,6 @@ import org.gradle.api.internal.HasConvention
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.util.GradleVersion
-import org.unbrokendome.gradle.plugins.xjc.internal.GRADLE_VERSION_6_1
 import org.unbrokendome.gradle.plugins.xjc.internal.MIN_REQUIRED_GRADLE_VERSION
 
 
@@ -41,6 +40,9 @@ class XjcPlugin : Plugin<Project> {
             "3.0" to listOf(
                 "com.sun.xml.bind:jaxb-xjc:3.0.0-M4",
                 "com.sun.xml.bind:jaxb-impl:3.0.0-M4"
+            ),
+            "4.0" to listOf(
+                "com.sun.xml.bind:jaxb-xjc:4.0.2"
             )
         )
     }
@@ -129,14 +131,8 @@ class XjcPlugin : Plugin<Project> {
 
                 val xjcOutputDir = generateTask.flatMap { it.outputDirectory }
 
-                if (GradleVersion.current() >= GRADLE_VERSION_6_1) {
-                    xjcSourceSetConvention.xjcSchema.destinationDirectory.set(xjcOutputDir)
-                    sourceSet.java.srcDir(xjcOutputDir)
-                } else {
-                    xjcSourceSetConvention.xjcSchema.outputDir =
-                        project.file(generateTask.flatMap { it.outputDirectory })
-                    sourceSet.java.srcDir(xjcOutputDir)
-                }
+                xjcSourceSetConvention.xjcSchema.destinationDirectory.set(xjcOutputDir)
+                sourceSet.java.srcDir(xjcOutputDir)
 
                 sourceSet.resources.srcDir(
                     generateTask.flatMap { it.episodeOutputDirectory }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/internal/GradleVersions.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/internal/GradleVersions.kt
@@ -3,6 +3,4 @@ package org.unbrokendome.gradle.plugins.xjc.internal
 import org.gradle.util.GradleVersion
 
 
-internal val GRADLE_VERSION_6_1 = GradleVersion.version("6.1")
-
-internal val MIN_REQUIRED_GRADLE_VERSION = GradleVersion.version("5.6")
+internal val MIN_REQUIRED_GRADLE_VERSION = GradleVersion.version("6.8")

--- a/src/xjc40/kotlin/org/unbrokendome/gradle/plugins/xjc/work/xjc40/XjcGeneratorWorkAction.kt
+++ b/src/xjc40/kotlin/org/unbrokendome/gradle/plugins/xjc/work/xjc40/XjcGeneratorWorkAction.kt
@@ -1,0 +1,9 @@
+package org.unbrokendome.gradle.plugins.xjc.work.xjc40
+
+import org.unbrokendome.gradle.plugins.xjc.work.common.AbstractXjcGeneratorWorkAction
+import javax.inject.Inject
+
+
+@Suppress("unused") // instantiated dynamically
+abstract class XjcGeneratorWorkAction
+@Inject constructor(): AbstractXjcGeneratorWorkAction()


### PR DESCRIPTION
- Drop support for Gradle versions before 6.8
- Added support for Gradle 8.0
- Kotlin upgrade to 1.8.10
- Upgrade to Asciidoc Plugin JVM plugin
- More dependency/plugin upgrades
- Added support for JAXB/XJC v4.0