### PR TITLE
Plugin 2024 Q1 maintenance update (115 commits) 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+registries:
+  gradle-plugin-portal:
+    type: maven-repository
+    url: https://plugins.gradle.org/m2
+    username: dummy # Required by dependabot
+    password: dummy # Required by dependabot
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           echo "target_version=$target_version" >> $GITHUB_ENV
 
       - name: Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.jvm }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,37 +51,32 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.jvm }}
 
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties', '**/gradle.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      - name: Gradle - wrapper-validation-action
+        uses: gradle/wrapper-validation-action@v1
 
       - name: Gradle - setup
         uses: gradle/gradle-build-action@v2
 
-      - name: Gradle - build
-        run: ./gradlew build
+      - name: Gradle - assemble
+        env: # to resolve artifacts from GH packages
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew $GRADLE_EXTRA_ARGS assemble
 
       - name: Gradle - check
-        run: ./gradlew check
+        run: ./gradlew $GRADLE_EXTRA_ARGS check
 
       - name: Gradle - integrationTest
         if: ${{ vars.GRADLE_TARGET_ENABLE_integrationTest == 'true' || inputs.GRADLE_TARGET_ENABLE_integrationTest }}
-        run: ./gradlew integrationTest
+        run: ./gradlew $GRADLE_EXTRA_ARGS integrationTest
 
       - name: Gradle - asciidoctor
-        run: ./gradlew asciidoctor
+        run: ./gradlew $GRADLE_EXTRA_ARGS asciidoctor
 
       - name: Gradle - dokka
-        run: ./gradlew dokka
+        run: ./gradlew $GRADLE_EXTRA_ARGS dokka
 
       - name: Gradle - publish
-        run: ./gradlew publish
+        run: ./gradlew $GRADLE_EXTRA_ARGS publish
 
       - name: Upload - prepare
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -129,6 +124,8 @@ jobs:
     needs: build
 
     runs-on: ubuntu-latest
+    env:
+      GRADLE_EXTRA_ARGS: --no-daemon
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,11 @@ jobs:
 
           mkdir -p build/gh-pages
           cp -a build/reports/tests build/gh-pages/
-          cp -a build/asciidoc/html5/* build/gh-pages/
-          cp -a build/dokka build/gh-pages/
+
+          docs_build_dir="build"
+          [ -d docs/build ] && docs_build_dir="docs/build" || true
+          cp -a $docs_build_dir/asciidoc/html5/* build/gh-pages/
+          cp -a $docs_build_dir/dokka build/gh-pages/
 
           mkdir -p build/gh-pages/maven2
           cp -a build/repo/* build/gh-pages/maven2/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,4 +265,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,4 +272,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
           retention-days: 1
 
       - name: Upload - perform
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: java${{ matrix.jvm }}-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,25 +152,25 @@ jobs:
           echo "target_version=$target_version" >> $GITHUB_ENV
 
       - name: Download - java8-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: java8-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
           path: build/java8-artifacts/
 
       - name: Download - java8-github-pages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: java8-github-pages
           path: build/java8-github-pages-artifacts/
 
       - name: Download - java11-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: java11-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
           path: build/java11-artifacts/
 
       - name: Download - java11-github-pages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: java11-github-pages
           path: build/java11-github-pages-artifacts/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,4 +265,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: CI-Gradle-build
 
 on:
   push:
+    branches:
+      - master
   release:
   workflow_dispatch:
     inputs:
@@ -13,6 +15,7 @@ on:
     # FIXME we probably want this to work on the latest release tag only
     # * is a special character in YAML
     # setup monthly background build
+    # Hmm GH won't run schedule if no activity for 2 months
     - cron: '45 4 18 * *'
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Version
         run: |
@@ -128,7 +128,7 @@ jobs:
       GRADLE_EXTRA_ARGS: --no-daemon
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Version
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,17 +227,17 @@ jobs:
           ls -lR build
 
       - name: github-pages - artifacts/ Generate Directory Listings
-        uses: jayanta525/github-pages-directory-listing@19ee734e017b656528749434335f75a1efb931bc
+        uses: jayanta525/github-pages-directory-listing@624ac8c4e56893256d3772f61a88e3b14d54314e
         with:
           FOLDER: build/gh-pages/artifacts/      #directory to generate index
 
       - name: github-pages - java8/ Generate Directory Listings
-        uses: jayanta525/github-pages-directory-listing@19ee734e017b656528749434335f75a1efb931bc
+        uses: jayanta525/github-pages-directory-listing@624ac8c4e56893256d3772f61a88e3b14d54314e
         with:
           FOLDER: build/gh-pages/java8/          #directory to generate index
 
       - name: github-pages - java11/ Generate Directory Listings
-        uses: jayanta525/github-pages-directory-listing@19ee734e017b656528749434335f75a1efb931bc
+        uses: jayanta525/github-pages-directory-listing@624ac8c4e56893256d3772f61a88e3b14d54314e
         with:
           FOLDER: build/gh-pages/java11/         #directory to generate index
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,84 @@
+name: CI-Gradle-build
+
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML
+    # setup monthly background build
+    - cron: '45 4 18 * *'
+
+jobs:
+  gradle:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        jvm: ['8', '11']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Version
+        run: |
+          target_plugin="org.unbroken-dome.xjc"
+          target_group=$(grep "^group=" gradle.properties | cut -d'=' -f2-)
+          target_artifact="gradle-xjc-plugin"
+          target_version=$(grep "^version=" gradle.properties | cut -d'=' -f2-)
+
+          echo "target_plugin=$target_plugin" >> $GITHUB_ENV
+          echo "target_group=$target_group" >> $GITHUB_ENV
+          echo "target_artifact=$target_artifact" >> $GITHUB_ENV
+          echo "target_version=$target_version" >> $GITHUB_ENV
+
+      - name: Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.jvm }}
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties', '**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Gradle - setup
+        uses: gradle/gradle-build-action@v2
+
+      - name: Gradle - build
+        run: ./gradlew build
+
+      - name: Gradle - check
+        run: ./gradlew check
+
+      - name: Gradle - integrationTest
+        if: ${{ vars.GRADLE_TARGET_ENABLE_integrationTest == 'true' }}
+        run: ./gradlew integrationTest
+
+      - name: Gradle - publish
+        run: ./gradlew publish
+
+      - name: Upload - prepare
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        shell: bash
+        run: |
+          mkdir dist;
+          for dir in $(find . -type d -path "*/build/repo");
+          do
+            cp -a "$dir" "dist/";
+          done
+          find "dist" -type f -exec ls -ld {} \;
+          du -s "dist"
+
+      - name: Upload - perform
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        with:
+          name: java${{ matrix.jvm }}-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
+          path: dist/repo/*
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         jvm: ['8', '11']
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,11 @@ name: CI-Gradle-build
 on:
   push:
   workflow_dispatch:
+    inputs:
+      GRADLE_TARGET_ENABLE_integrationTest:
+        description: 'Run with integrationTest ?'
+        default: false
+        type: boolean
   schedule:
     # * is a special character in YAML
     # setup monthly background build
@@ -21,6 +26,10 @@ jobs:
 
       - name: Version
         run: |
+          if [ -z "${GRADLE_TARGET_ENABLE_integrationTest}" ] && [ -n "${{ github.event.schedule }}" ]; then
+            # force this on for schedule build
+            echo "GRADLE_TARGET_ENABLE_integrationTest=true" >> $GITHUB_ENV
+          fi
           target_plugin="org.unbroken-dome.xjc"
           target_group=$(grep "^group=" gradle.properties | cut -d'=' -f2-)
           target_artifact="gradle-xjc-plugin"
@@ -57,7 +66,7 @@ jobs:
         run: ./gradlew check
 
       - name: Gradle - integrationTest
-        if: ${{ vars.GRADLE_TARGET_ENABLE_integrationTest == 'true' }}
+        if: ${{ vars.GRADLE_TARGET_ENABLE_integrationTest == 'true' || inputs.GRADLE_TARGET_ENABLE_integrationTest }}
         run: ./gradlew integrationTest
 
       - name: Gradle - publish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: CI-Gradle-build
 
 on:
   push:
+  release:
   workflow_dispatch:
     inputs:
       GRADLE_TARGET_ENABLE_integrationTest:
@@ -9,6 +10,7 @@ on:
         default: false
         type: boolean
   schedule:
+    # FIXME we probably want this to work on the latest release tag only
     # * is a special character in YAML
     # setup monthly background build
     - cron: '45 4 18 * *'
@@ -248,6 +250,7 @@ jobs:
 
 
   deploy:
+    if: ( github.ref == 'master' && github.event_name == 'push' ) || github.event_name == 'release' || github.event_name == 'schedule'
     needs: gh-pages-prepare
 
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
     - cron: '45 4 18 * *'
 
 jobs:
-  gradle:
+  build:
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -29,6 +29,8 @@ jobs:
         run: |
           if [ -z "${GRADLE_TARGET_ENABLE_integrationTest}" ] && [ -n "${{ github.event.schedule }}" ]; then
             # force this on for schedule build
+            # "${{ github.event.schedule }}" == "45 4 18 * *"
+            # $GITHUB_EVENT_NAME == "schedule"
             echo "GRADLE_TARGET_ENABLE_integrationTest=true" >> $GITHUB_ENV
           fi
           target_plugin="org.unbroken-dome.xjc"
@@ -70,6 +72,12 @@ jobs:
         if: ${{ vars.GRADLE_TARGET_ENABLE_integrationTest == 'true' || inputs.GRADLE_TARGET_ENABLE_integrationTest }}
         run: ./gradlew integrationTest
 
+      - name: Gradle - asciidoctor
+        run: ./gradlew asciidoctor
+
+      - name: Gradle - dokka
+        run: ./gradlew dokka
+
       - name: Gradle - publish
         run: ./gradlew publish
 
@@ -85,6 +93,24 @@ jobs:
           find "dist" -type f -exec ls -ld {} \;
           du -s "dist"
 
+          mkdir -p build/gh-pages
+          cp -a build/reports/tests build/gh-pages/
+          cp -a build/asciidoc/html5/* build/gh-pages/
+          cp -a build/dokka build/gh-pages/
+
+          mkdir -p build/gh-pages/maven2
+          cp -a build/repo/* build/gh-pages/maven2/
+
+          ls -lad build/gh-pages
+          du -s build/gh-pages
+
+      - name: Upload - java${{ matrix.jvm }}-github-pages
+        uses: actions/upload-pages-artifact@main
+        with:
+          name: java${{ matrix.jvm }}-github-pages
+          path: build/gh-pages/
+          retention-days: 1
+
       - name: Upload - perform
         uses: actions/upload-artifact@v3
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -92,3 +118,148 @@ jobs:
           name: java${{ matrix.jvm }}-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
           path: dist/repo/*
           if-no-files-found: error
+
+
+  gh-pages-prepare:
+    needs: build
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Version
+        run: |
+          if [ -z "${GRADLE_TARGET_ENABLE_integrationTest}" ] && [ -n "${{ github.event.schedule }}" ]; then
+            # force this on for schedule build
+            # "${{ github.event.schedule }}" == "45 4 18 * *"
+            # $GITHUB_EVENT_NAME == "schedule"
+            echo "GRADLE_TARGET_ENABLE_integrationTest=true" >> $GITHUB_ENV
+          fi
+          target_plugin="org.unbroken-dome.xjc"
+          target_group=$(grep "^group=" gradle.properties | cut -d'=' -f2-)
+          target_artifact="gradle-xjc-plugin"
+          target_version=$(grep "^version=" gradle.properties | cut -d'=' -f2-)
+
+          echo "target_plugin=$target_plugin" >> $GITHUB_ENV
+          echo "target_group=$target_group" >> $GITHUB_ENV
+          echo "target_artifact=$target_artifact" >> $GITHUB_ENV
+          echo "target_version=$target_version" >> $GITHUB_ENV
+
+      - name: Download - java8-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: java8-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
+          path: build/java8-artifacts/
+
+      - name: Download - java8-github-pages
+        uses: actions/download-artifact@v3
+        with:
+          name: java8-github-pages
+          path: build/java8-github-pages-artifacts/
+
+      - name: Download - java11-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: java11-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
+          path: build/java11-artifacts/
+
+      - name: Download - java11-github-pages
+        uses: actions/download-artifact@v3
+        with:
+          name: java11-github-pages
+          path: build/java11-github-pages-artifacts/
+
+      - name: Shell
+        run: |
+          pwd
+          ls -la
+          find . -type f
+          ls -lR build
+
+          echo "#### build/java8-github-pages-artifacts/artifact.tar:"
+          #[ ! -f "build/java8-github-pages-artifacts/artifact.tar" ] || tar -tvf "build/java8-github-pages-artifacts/artifact.tar"
+          mkdir -p build/java8-github-pages/
+          tar -xvf build/java8-github-pages-artifacts/artifact.tar -C build/java8-github-pages/
+
+          echo "#### build/java11-github-pages-artifacts/artifact.tar:"
+          #[ ! -f "build/java11-github-pages-artifacts/artifact.tar" ] || tar -tvf "build/java11-github-pages-artifacts/artifact.tar"
+          mkdir -p build/java11-github-pages/
+          tar -xvf build/java11-github-pages-artifacts/artifact.tar -C build/java11-github-pages/
+          
+          mkdir -p build/gh-pages/
+
+          # build/gh-pages/artifacts
+          mkdir -p build/gh-pages/artifacts
+          tar -cf "build/gh-pages/artifacts/java8-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts.tar.gz"  -C build/java8-artifacts/ .
+          pushd build/java8-artifacts
+          zip -q -r  "../gh-pages/artifacts/java8-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts.zip"  .
+          popd
+          tar -cf "build/gh-pages/artifacts/java11-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts.tar.gz" -C build/java11-artifacts/ .
+          pushd build/java11-artifacts
+          zip -q -r  "../gh-pages/artifacts/java11-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts.zip" .
+          popd
+
+          # build/gh-pages/index.html (asciidoctor)
+          # build/gh-pages/dokka/
+          cp -av build/java8-github-pages/* build/gh-pages/
+
+          mkdir -p build/gh-pages/java8
+          # build/gh-pages/java8/tests/
+          cp -a build/java8-github-pages/tests build/gh-pages/java8/
+          # build/gh-pages/java8/maven2/
+          cp -a build/java8-github-pages/maven2    build/gh-pages/java8/
+          touch build/gh-pages/java8/maven2/M2_Java8_Artifacts.txt
+
+          mkdir -p build/gh-pages/java11
+          # build/gh-pages/java11/tests/
+          cp -a build/java11-github-pages/tests build/gh-pages/java11/
+          # build/gh-pages/java11/maven2/
+          cp -a build/java11-github-pages/maven2    build/gh-pages/java11/
+          touch build/gh-pages/java11/maven2/M2_Java11_Artifacts.txt
+
+          echo "#### DONE ####"
+          pwd
+          ls -la
+          find . -type f
+          ls -lR build
+
+      - name: github-pages - artifacts/ Generate Directory Listings
+        uses: jayanta525/github-pages-directory-listing@19ee734e017b656528749434335f75a1efb931bc
+        with:
+          FOLDER: build/gh-pages/artifacts/      #directory to generate index
+
+      - name: github-pages - java8/ Generate Directory Listings
+        uses: jayanta525/github-pages-directory-listing@19ee734e017b656528749434335f75a1efb931bc
+        with:
+          FOLDER: build/gh-pages/java8/          #directory to generate index
+
+      - name: github-pages - java11/ Generate Directory Listings
+        uses: jayanta525/github-pages-directory-listing@19ee734e017b656528749434335f75a1efb931bc
+        with:
+          FOLDER: build/gh-pages/java11/         #directory to generate index
+
+      - name: Upload - github-pages
+        uses: actions/upload-pages-artifact@main
+        with:
+          name: github-pages
+          path: build/gh-pages/
+          retention-days: 90
+
+
+  deploy:
+    needs: gh-pages-prepare
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,24 +154,28 @@ jobs:
       - name: Download - java8-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
         uses: actions/download-artifact@v4
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           name: java8-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
           path: build/java8-artifacts/
 
       - name: Download - java8-github-pages
         uses: actions/download-artifact@v4
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           name: java8-github-pages
           path: build/java8-github-pages-artifacts/
 
       - name: Download - java11-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
         uses: actions/download-artifact@v4
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           name: java11-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
           path: build/java11-artifacts/
 
       - name: Download - java11-github-pages
         uses: actions/download-artifact@v4
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           name: java11-github-pages
           path: build/java11-github-pages-artifacts/
 

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -175,9 +175,13 @@ jobs:
             8|*) echo "kotlinVersion=1.9.20"  >> gradle.properties
                  if [ "${{ matrix.jvm }}" = "8" ]
                  then
-                   echo "testSetsVersion=4.0.0" >> gradle.properties
+                   # The official org.unbroken-dome.test-sets 4.1.0 Needs Java11+ and is the first version to support Gradle 8.x
+                   #echo "testSetsVersion=4.0.0" >> gradle.properties
+                   # So this is why this if[] exists, but the we now use unofficial:
+                   #org.darrylmiles.repack.org.unbroken-dome.test-sets which a release in Java8 bytecode of 4.1.0
+                   echo "testSetsVersion=4.1.0" >> gradle.properties
                  else
-                   # Needs Java11+
+                   # The official org.unbroken-dome.test-sets 4.1.0 Needs Java11+
                    echo "testSetsVersion=4.1.0" >> gradle.properties
                  fi
                  ;;

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -190,7 +190,7 @@ jobs:
           cat gradle.properties
 
       - name: Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.jvm }}

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -67,7 +67,7 @@ jobs:
       GRADLE_EXTRA_ARGS: --no-daemon --warning-mode=all
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Matrix Check
         run: |

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -286,8 +286,11 @@ jobs:
 
           mkdir -p build/gh-pages
           [ -d build/reports/tests  ] && cp -a build/reports/tests    build/gh-pages/
-          [ -d build/asciidoc/html5 ] && cp -a build/asciidoc/html5/* build/gh-pages/
-          [ -d build/dokka          ] && cp -a build/dokka            build/gh-pages/
+
+          docs_build_dir="build"
+          [ -d docs/build ] && docs_build_dir="docs/build" || true
+          [ -d $docs_build_dir/asciidoc/html5 ] && cp -a $docs_build_dir/asciidoc/html5/* build/gh-pages/
+          [ -d $docs_build_dir/dokka          ] && cp -a $docs_build_dir/dokka            build/gh-pages/
 
           mkdir -p build/gh-pages/maven2
           [ -d "build/repo" ] && cp -a build/repo/* build/gh-pages/maven2/

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -311,7 +311,7 @@ jobs:
           retention-days: 1
 
       - name: Upload - perform
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: java${{ matrix.jvm }}-gradle${{ matrix.gradle }}-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts

--- a/.github/workflows/canary-build.yml
+++ b/.github/workflows/canary-build.yml
@@ -1,0 +1,312 @@
+name: CI-Gradle-canary-build
+# This build exists to test compatibility of the plugin project build to generate the plugin
+# with the latest Gradle version.
+# This is checking and reporting about the plugin maintainers perspective of building this plugin
+# This also indirectly tests against JVM updates as well but that is not considered the main focus
+#
+# So I'm calling this a canary as it provides an early warning after a new official Gradle release
+# of consumer issues.  We do not test release candidates or against any Gradle builds that are not
+# an official release as there is no maintenance capacity to keep uptodate with daily issues from
+# doing this not any reason to thing doing this will improve the quality of the plugin.
+#
+# Gradle publishes public data to in this area to help with automation:
+#   https://services.gradle.org/versions/
+#   https://raw.githubusercontent.com/gradle/gradle/master/released-versions.json
+
+## TODO build project test, using newer Gradle versions, setup matrix of useful version
+## TODO run deprecation test turn on warnings, collect output to summary
+## TODO emit compile log output warnings to summary
+
+on:
+  workflow_dispatch:
+    inputs:
+      GRADLE_TARGET_ENABLE_integrationTest:
+        description: 'Run with integrationTest ?'
+        default: true
+        type: boolean
+  schedule:
+    # setup weekly canary build
+    - cron: '45 4 * * 6'
+
+jobs:
+  build:
+    strategy:
+      max-parallel: 3
+      matrix:
+        # Maintenance update as necessary the expected latest Gradle version supports the JVM matrix listed
+        os: [ubuntu-latest]
+        jvm: ['8', '11', '17', '21']
+        gradle: [
+          'latest',
+          '8',
+          '8.5',  # JDK21
+          '7',
+          '7.6',
+          '7.3',  # JDK11
+          '6',
+          '6.6.1' # oldest supported to build project with
+        ]
+        exclude:
+          - jvm: 21
+            gradle: 7
+          - jvm: 21
+            gradle: 7.6
+          - jvm: 21
+            gradle: 7.3
+          - jvm: 21
+            gradle: 6
+          - jvm: 21
+            gradle: 6.6.1
+          - jvm: 17
+            gradle: 6
+          - jvm: 17
+            gradle: 6.6.1
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    env:
+      GRADLE_EXTRA_ARGS: --no-daemon --warning-mode=all
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Matrix Check
+        run: |
+          ## Disable runs requesting invalid matrix (done via 'strategy.matrix.exclude' GHA setting)
+          # jvm=21 only latest 8.5
+          # jvm=17 only latest 8.5 7 7.6 7.3
+          # jvm=11 only latest 8.5 7 7.6 7.3 6 5 5.6
+          # jvm=8 only latest 8.5 7 7.6 7.3 6 5 5.6
+          # Resolve all values to actual value
+          # Remove duplicates (and alias runs)
+          if [ -z "${{ matrix.os }}" ]
+          then
+            echo "$0: matrix.os is not setup" 1>&2
+            exit 1
+          fi
+          if [ -z "${{ matrix.jvm }}" ]
+          then
+            echo "$0: matrix.jvm is not setup" 1>&2
+            exit 1
+          fi
+          if [ -z "${{ matrix.gradle }}" ]
+          then
+            echo "$0: matrix.gradle is not setup" 1>&2
+            exit 1
+          fi
+
+      - name: GHA Option Setup
+        run: |
+          if [ -z "${GRADLE_TARGET_ENABLE_integrationTest}" ] && [ -n "${{ github.event.schedule }}" ]; then
+            # force this on for schedule build
+            # "${{ github.event.schedule }}" == "45 4 18 * *"
+            # $GITHUB_EVENT_NAME == "schedule"
+            echo "GRADLE_TARGET_ENABLE_integrationTest=true" >> $GITHUB_ENV
+          fi
+          target_plugin="org.unbroken-dome.xjc"
+          target_group=$(grep "^group=" gradle.properties | cut -d'=' -f2-)
+          target_artifact="gradle-xjc-plugin"
+          target_version=$(grep "^version=" gradle.properties | cut -d'=' -f2-)
+
+          echo "target_plugin=$target_plugin" >> $GITHUB_ENV
+          echo "target_group=$target_group" >> $GITHUB_ENV
+          echo "target_artifact=$target_artifact" >> $GITHUB_ENV
+          echo "target_version=$target_version" >> $GITHUB_ENV
+
+      - name: Gradle Version Setup
+        run: |
+          # 
+          curl -s "https://raw.githubusercontent.com/gradle/gradle/master/released-versions.json" > released-versions.json
+
+          # Only supporting 6.6.1 or newer (to build the project itself)
+          GRADLE_ALL_VERSIONS=$(jq '.finalReleases[].version' -r released-versions.json | sort -rn | tr '\n' ' ' | sed -e 's#\s6.6\s.*##')
+          echo "GRADLE_ALL_VERSIONS=$GRADLE_ALL_VERSIONS"
+
+          GRADLE_CANARY_VERSION=$(jq '.finalReleases[].version' -r released-versions.json | sort -rn | head -n1)
+          echo "GRADLE_CANARY_VERSION=$GRADLE_CANARY_VERSION"
+
+          GRADLE_CANARY_MAJOR=$(echo -n "$GRADLE_CANARY_VERSION" | cut -d '.' -f1)
+
+          regex_transform=$(echo -ne "${{ matrix.gradle }}" | sed -e 's#\.#\\\0#g')
+          GRADLE_MATRIX_VERSION=$(jq '.finalReleases[].version' -r released-versions.json | sort -rn | egrep -- "^${regex_transform}" | head -n1 | tr -d '\r\n')
+          echo "GRADLE_MATRIX_VERSION=$GRADLE_MATRIX_VERSION"
+
+          GRADLE_MATRIX_MAJOR=$(echo -n "$GRADLE_MATRIX_VERSION" | cut -d '.' -f1)
+
+          if gradlew -v || which gradlew
+          then
+            # confirm GHA didn't provide its own
+            echo "$0: ERROR ./gradlew appears to already be installed" 1>&2
+            exit 1
+          fi
+
+          if [ "${{ matrix.gradle }}" = "latest" ]
+          then
+            GRADLE_VERSION="$GRADLE_CANARY_VERSION"
+          else
+            GRADLE_VERSION="$GRADLE_MATRIX_VERSION"
+          fi
+          GRADLE_VERSION_MAJOR=$(echo -n "$GRADLE_VERSION" | cut -d '.' -f1)
+
+          # TODO disable duplicate runs which resolve to the same matrix versions
+          # latest 8 8.5 all resolve to 8.5 for example
+
+          echo "GRADLE_ALL_VERSIONS=$GRADLE_ALL_VERSIONS" >> $GITHUB_ENV
+          echo "GRADLE_CANARY_VERSION=$GRADLE_CANARY_VERSION" >> $GITHUB_ENV
+          echo "GRADLE_CANARY_MAJOR=$GRADLE_CANARY_MAJOR" >> $GITHUB_ENV
+          echo "GRADLE_MATRIX_VERSION=$GRADLE_MATRIX_VERSION" >> $GITHUB_ENV
+          echo "GRADLE_MATRIX_MAJOR=$GRADLE_MATRIX_MAJOR" >> $GITHUB_ENV
+          echo "GRADLE_VERSION=$GRADLE_VERSION" >> $GITHUB_ENV
+          echo "GRADLE_VERSION_MAJOR=$GRADLE_VERSION_MAJOR" >> $GITHUB_ENV
+
+          # Make the version so with wrapper edit
+          sed -e 's/^distributionUrl=/\#\0/' -i gradle/wrapper/gradle-wrapper.properties
+          echo "distributionUrl=https\://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-all.zip" >> gradle/wrapper/gradle-wrapper.properties
+
+          # Fixup gradle.properties based on Gradle major used to build
+          sed -e 's/^kotlinVersion=/\#\0/'   -i gradle.properties
+          sed -e 's/^testSetsVersion=/\#\0/' -i gradle.properties
+          case "$GRADLE_VERSION_MAJOR" in
+            5|6) echo "kotlinVersion=1.3.72"  >> gradle.properties
+                 echo "testSetsVersion=3.0.1" >> gradle.properties
+                 ;;
+            7)   echo "kotlinVersion=1.6.21"  >> gradle.properties
+                 echo "testSetsVersion=4.0.0" >> gradle.properties
+                 ;;
+            8|*) echo "kotlinVersion=1.9.20"  >> gradle.properties
+                 if [ "${{ matrix.jvm }}" = "8" ]
+                 then
+                   echo "testSetsVersion=4.0.0" >> gradle.properties
+                 else
+                   # Needs Java11+
+                   echo "testSetsVersion=4.1.0" >> gradle.properties
+                 fi
+                 ;;
+          esac
+          echo "### gradle.properties:"
+          cat gradle.properties
+
+      - name: Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.jvm }}
+
+      - name: Gradle - wrapper-validation-action
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Gradle - setup
+        uses: gradle/gradle-build-action@v2
+
+      - name: Show Diff
+        run: |
+          git diff || true
+
+      - name: Report Versions
+        run: |
+          # Print verbose diagnostics into logs
+          java -version
+
+          # download-artifact removes executable perm from files
+          test -x ./gradlew || chmod -c a+x ./gradlew
+          # Now run it
+          ./gradlew -v
+
+          JAVA_ARG_VERSION=$(java -version 2>&1 | sed -e ':a;N;$!ba;s/\n/<br>/g' -e 's#|#\\|#g')
+          JAVA_ARG_VERSION_SUMMARY=$(java -version 2>&1 | head -n1 | sed -e 's#openjdk\s\+##' -e 's#version\s\+##' -e 's#"##g' -e 's#\s\+.*$##')
+          GRADLE_ARG_VERSION=$(./gradlew -v 2>&1 | sed -e ':a;N;$!ba;s/\n/<br>/g' -e 's#|#\\|#g')
+          GRADLE_WRAPPER_VERSION=$(egrep "^distributionUrl\s*=" gradle/wrapper/gradle-wrapper.properties | sed -e 's#^.*=##' -e 's#.*distributions/##' -e 's#^gradle\-##' -e 's#\-.*$##')
+
+          cat <<EOF >> /tmp/GITHUB_STEP_SUMMARY$$.txt
+          Gradle Version $GRADLE_VERSION (${{ matrix.gradle }})  JDK $JAVA_ARG_VERSION_SUMMARY (${{ matrix.jvm }})
+
+          | Package    | Details               |
+          | ---------- | --------------------- |
+          | Java       | ${JAVA_ARG_VERSION}   |
+          | Gradle     | ${GRADLE_ARG_VERSION} |
+          EOF
+
+          cat /tmp/GITHUB_STEP_SUMMARY$$.txt
+          cat /tmp/GITHUB_STEP_SUMMARY$$.txt >> $GITHUB_STEP_SUMMARY
+
+      - name: Gradle - dependencies
+        env: # to resolve artifacts from GH packages
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew $GRADLE_EXTRA_ARGS dependencies
+
+      - name: Gradle - assemble
+        env: # to resolve artifacts from GH packages
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew $GRADLE_EXTRA_ARGS assemble
+
+      - name: Gradle - build
+        run: ./gradlew $GRADLE_EXTRA_ARGS build
+
+      - name: Gradle - check
+        run: |
+          if ! ./gradlew $GRADLE_EXTRA_ARGS check
+          then
+            ./gradlew $GRADLE_EXTRA_ARGS --stacktrace check
+          fi
+
+      - name: Gradle - integrationTest
+        if: ${{ vars.GRADLE_TARGET_ENABLE_integrationTest == 'true' || inputs.GRADLE_TARGET_ENABLE_integrationTest }}
+        run: ./gradlew $GRADLE_EXTRA_ARGS "-Dorg.unbrokendome.gradle.plugins.xjc.testutil.GradleVersions=${GRADLE_VERSION}" integrationTest
+
+      - name: Gradle - asciidoctor
+        if: false  # needs fixing for 7.x
+        run: ./gradlew $GRADLE_EXTRA_ARGS asciidoctor
+
+      - name: Gradle - dokka
+        if: false  # needs fixing for 7.x
+        run: ./gradlew $GRADLE_EXTRA_ARGS dokka
+
+      - name: Gradle - publish
+        run: ./gradlew $GRADLE_EXTRA_ARGS publish
+
+      - name: Gradle - deprecation check
+        run: ./gradlew -Dorg.gradle.deprecation.trace=true --warning-mode=all --stacktrace validatePlugins
+
+      - name: Upload - prepare
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        shell: bash
+        run: |
+          mkdir dist
+          _build_repo_list=$(find . -type d -path "*/build/repo")
+          if [ -n "${_build_repo_list}" ]
+          then
+            for dir in ${_build_repo_list}
+            do
+              cp -a "$dir" "dist/"
+            done
+          else
+            echo "$0: no **/build/repo directories found" 1>&2
+          fi
+          find "dist" -type f -exec ls -ld {} \;
+          du -s "dist"
+
+          mkdir -p build/gh-pages
+          [ -d build/reports/tests  ] && cp -a build/reports/tests    build/gh-pages/
+          [ -d build/asciidoc/html5 ] && cp -a build/asciidoc/html5/* build/gh-pages/
+          [ -d build/dokka          ] && cp -a build/dokka            build/gh-pages/
+
+          mkdir -p build/gh-pages/maven2
+          [ -d "build/repo" ] && cp -a build/repo/* build/gh-pages/maven2/
+
+          ls -lad build/gh-pages
+          du -s build/gh-pages
+
+      - name: Upload - java${{ matrix.jvm }}-gradle${{ matrix.gradle }}-github-pages
+        uses: actions/upload-pages-artifact@main
+        if: false
+        with:
+          name: java${{ matrix.jvm }}-github-pages
+          path: build/gh-pages/
+          retention-days: 1
+
+      - name: Upload - perform
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        with:
+          name: java${{ matrix.jvm }}-gradle${{ matrix.gradle }}-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-artifacts
+          path: dist/repo/*
+          if-no-files-found: warn

--- a/.github/workflows/canary-consume.yml
+++ b/.github/workflows/canary-consume.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: GHA Option Setup
         run: |
@@ -237,7 +237,7 @@ jobs:
       
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: original
 

--- a/.github/workflows/canary-consume.yml
+++ b/.github/workflows/canary-consume.yml
@@ -1,0 +1,481 @@
+name: CI-Gradle-canary-consume
+# This build exists to test compatibility of the plugin produces with the latest Gradle version
+# This is checking and reporting about the user perspective of consuming this plugin
+# This also indirectly tests against JVM updates as well but that is not considered the main focus
+#
+# So I'm calling this a canary as it provides an early warning after a new official Gradle release
+# of consumer issues.  We do not test release candidates or against any Gradle builds that are not
+# an official release as there is no maintenance capacity to keep uptodate with daily issues from
+# doing this not any reason to thing doing this will improve the quality of the plugin.
+#
+# Gradle publishes public data to in this area to help with automation:
+#   https://services.gradle.org/versions/
+#   https://raw.githubusercontent.com/gradle/gradle/master/released-versions.json
+
+## TODO build project test, using newer Gradle versions, setup matrix of useful version
+## TODO run deprecation test turn on warnings, collect output to summary
+## TODO emit compile log output warnings to summary
+
+on:
+  workflow_dispatch:
+    inputs:
+      GRADLE_TARGET_ENABLE_integrationTest:
+        description: 'Run with integrationTest ?'
+        default: true
+        type: boolean
+  schedule:
+    # setup weekly canary consume
+    - cron: '45 4 * * 6'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GHA_INPUT_BUILD_JVM: 8
+      GRADLE_EXTRA_ARGS: --no-daemon
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: GHA Option Setup
+        run: |
+          if [ -f "original/gradle.properties" ]
+          then
+            gradle_properties_path="original/gradle.properties"
+          else
+            gradle_properties_path="gradle.properties"
+          fi
+
+          if [ -z "${GRADLE_TARGET_ENABLE_integrationTest}" ] && [ -n "${{ github.event.schedule }}" ]; then
+            # force this on for schedule build
+            # "${{ github.event.schedule }}" == "45 4 18 * *"
+            # $GITHUB_EVENT_NAME == "schedule"
+            echo "GRADLE_TARGET_ENABLE_integrationTest=true" >> $GITHUB_ENV
+          fi
+          target_plugin="org.unbroken-dome.xjc"
+          target_group=$(grep "^group=" $gradle_properties_path | cut -d'=' -f2-)
+          target_artifact="gradle-xjc-plugin"
+          target_version=$(grep "^version=" $gradle_properties_path | cut -d'=' -f2-)
+
+          echo "target_plugin=$target_plugin" >> $GITHUB_ENV
+          echo "target_group=$target_group" >> $GITHUB_ENV
+          echo "target_artifact=$target_artifact" >> $GITHUB_ENV
+          echo "target_version=$target_version" >> $GITHUB_ENV
+
+      - name: Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ env.GHA_INPUT_BUILD_JVM }}
+
+      - name: Gradle - wrapper-validation-action
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Gradle - setup
+        uses: gradle/gradle-build-action@v2
+
+      - name: Report Versions
+        run: |
+          # Print verbose diagnostics into logs
+          java -version
+
+          # download-artifact removes executable perm from files
+          test -x ./gradlew || chmod -c a+x ./gradlew
+          # Now run it
+          ./gradlew -v
+
+          JAVA_ARG_VERSION=$(java -version 2>&1 | sed -e ':a;N;$!ba;s/\n/<br>/g' -e 's#|#\\|#g')
+          JAVA_ARG_VERSION_SUMMARY=$(java -version 2>&1 | head -n1 | sed -e 's#openjdk\s\+##' -e 's#version\s\+##' -e 's#"##g' -e 's#\s\+.*$##')
+          GRADLE_ARG_VERSION=$(./gradlew -v 2>&1 | sed -e ':a;N;$!ba;s/\n/<br>/g' -e 's#|#\\|#g')
+          GRADLE_WRAPPER_VERSION=$(egrep "^distributionUrl\s*=" gradle/wrapper/gradle-wrapper.properties | sed -e 's#^.*=##' -e 's#.*distributions/##' -e 's#^gradle\-##' -e 's#\-.*$##')
+
+          cat <<EOF >> /tmp/GITHUB_STEP_SUMMARY$$.txt
+          Gradle Version $GRADLE_VERSION (wrapper ${GRADLE_WRAPPER_VERSION})  JDK $JAVA_ARG_VERSION_SUMMARY (${{ env.GHA_INPUT_BUILD_JVM }})
+
+          | Package    | Details               |
+          | ---------- | --------------------- |
+          | Java       | ${JAVA_ARG_VERSION}   |
+          | Gradle     | ${GRADLE_ARG_VERSION} |
+          EOF
+
+          cat /tmp/GITHUB_STEP_SUMMARY$$.txt
+          cat /tmp/GITHUB_STEP_SUMMARY$$.txt >> $GITHUB_STEP_SUMMARY
+
+      - name: Gradle - dependencies
+        env: # to resolve artifacts from GH packages
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew $GRADLE_EXTRA_ARGS dependencies
+
+      - name: Gradle - assemble
+        env: # to resolve artifacts from GH packages
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew $GRADLE_EXTRA_ARGS assemble
+
+      - name: Gradle - check
+        run: ./gradlew $GRADLE_EXTRA_ARGS check
+
+      - name: Gradle - integrationTest
+        if: ${{ vars.GRADLE_TARGET_ENABLE_integrationTest == 'true' || inputs.GRADLE_TARGET_ENABLE_integrationTest }}
+        run: ./gradlew $GRADLE_EXTRA_ARGS "-Dorg.unbrokendome.gradle.plugins.xjc.testutil.GradleVersions=${GRADLE_VERSION}" integrationTest
+
+      - name: Gradle - asciidoctor
+        run: ./gradlew $GRADLE_EXTRA_ARGS asciidoctor
+
+      - name: Gradle - dokka
+        run: ./gradlew $GRADLE_EXTRA_ARGS dokka
+
+      - name: Gradle - publish
+        run: ./gradlew $GRADLE_EXTRA_ARGS publish
+
+      - name: Gradle - deprecation check
+        run: ./gradlew $GRADLE_EXTRA_ARGS publish
+
+      - name: Upload - prepare
+        if: true  # ${{ matrix.os == 'ubuntu-latest' }}
+        shell: bash
+        run: |
+          mkdir dist
+          _build_repo_list=$(find . -type d -path "*/build/repo")
+          if [ -n "${_build_repo_list}" ]
+          then
+            for dir in ${_build_repo_list}
+            do
+              cp -a "$dir" "dist/"
+            done
+          else
+            echo "$0: no **/build/repo directories found" 1>&2
+          fi
+          find "dist" -type f -exec ls -ld {} \;
+          du -s "dist"
+
+          mkdir -p build/gh-pages
+          [ -d build/reports/tests  ] && cp -a build/reports/tests    build/gh-pages/
+          [ -d build/asciidoc/html5 ] && cp -a build/asciidoc/html5/* build/gh-pages/
+          [ -d build/dokka          ] && cp -a build/dokka            build/gh-pages/
+
+          mkdir -p build/gh-pages/maven2
+          [ -d "build/repo" ] && cp -a build/repo/* build/gh-pages/maven2/
+
+          ls -lad build/gh-pages
+          du -s build/gh-pages
+
+      - name: Upload - java${{ matrix.jvm }}-gradle${{ matrix.gradle }}-github-pages
+        uses: actions/upload-pages-artifact@main
+        if: false
+        with:
+          name: java${{ matrix.jvm }}-github-pages
+          path: build/gh-pages/
+          retention-days: 1
+
+      - name: Upload - perform
+        uses: actions/upload-artifact@v3
+        if: true  # ${{ matrix.os == 'ubuntu-latest' }}
+        with:
+          name: java${{ env.GHA_INPUT_BUILD_JVM }}-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-build-artifacts
+          path: '*'
+          if-no-files-found: error
+
+  
+  # Now we have the plugin built using release engineering settings (such as Java8 built with Gradle 6.6.1)
+  #  we now consume it and perform tests across multiple JVMs and Gradle combintations.  The integrationTest
+  #  matrix suite already gets the project a long way there on this.
+  # TODO use a plugin repository source override to be the build/repo/** output directory from 'build' job.
+  #  Then switch the checkout/download-artifact to place the downloaded copy in a subdir and provide options
+  #  to ensure gradle.  Need to execute 
+  consume:
+    needs: build
+    strategy:
+      max-parallel: 3
+      matrix:
+        # Maintenance update as necessary the expected latest Gradle version supports the JVM matrix listed
+        os: [ubuntu-latest]
+        jvm: ['8', '11', '17', '21']
+        gradle: [
+          'latest',
+          '8',
+          '8.5',   # JDK21
+          '7',
+          '7.6',
+          '7.3',   # JDK11
+          '6',
+          '6.6.1', # self-hosted build/consume
+          '5',
+          '5.6'
+        ]
+        exclude:
+          - jvm: 21
+            gradle: 7
+          - jvm: 21
+            gradle: 7.6
+          - jvm: 21
+            gradle: 7.3
+          - jvm: 21
+            gradle: 6
+          - jvm: 21
+            gradle: 6.6.1
+          - jvm: 21
+            gradle: 5
+          - jvm: 21
+            gradle: 5.6
+          - jvm: 17
+            gradle: 6
+          - jvm: 17
+            gradle: 6.6.1
+          - jvm: 17
+            gradle: 5
+          - jvm: 17
+            gradle: 5.6
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    env:
+      GRADLE_EXTRA_ARGS: -DexcludeDocsTasks=true --no-daemon --warning-mode=all
+      GHA_INPUT_BUILD_JVM: 8
+      
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: original
+
+      - name: GHA Option Setup
+        run: |
+          if [ -f "original/gradle.properties" ]
+          then
+            gradle_properties_path="original/gradle.properties"
+          else
+            gradle_properties_path="gradle.properties"
+          fi
+
+          if [ -z "${GRADLE_TARGET_ENABLE_integrationTest}" ] && [ -n "${{ github.event.schedule }}" ]; then
+            # force this on for schedule build
+            # "${{ github.event.schedule }}" == "45 4 18 * *"
+            # $GITHUB_EVENT_NAME == "schedule"
+            echo "GRADLE_TARGET_ENABLE_integrationTest=true" >> $GITHUB_ENV
+          fi
+          target_plugin="org.unbroken-dome.xjc"
+          target_group=$(grep "^group=" $gradle_properties_path | cut -d'=' -f2-)
+          target_artifact="gradle-xjc-plugin"
+          target_version=$(grep "^version=" $gradle_properties_path | cut -d'=' -f2-)
+
+          echo "target_plugin=$target_plugin" >> $GITHUB_ENV
+          echo "target_group=$target_group" >> $GITHUB_ENV
+          echo "target_artifact=$target_artifact" >> $GITHUB_ENV
+          echo "target_version=$target_version" >> $GITHUB_ENV
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: java${{ env.GHA_INPUT_BUILD_JVM }}-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-build-artifacts
+          path: .
+
+      - name: Matrix Check
+        run: |
+          pwd
+          ls -la
+          # TODO We restored the build, so the dist should not be here, when we use plugin respotory from local files dist/repo
+          #  we can check out clean project here and this move won't be needed
+          [ -d dist ] && mv -v dist dist_moved
+
+          ## Disable runs requesting invalid matrix (done via 'strategy.matrix.exclude' GHA setting)
+          # jvm=21 only latest 8.5
+          # jvm=17 only latest 8.5 7 7.6 7.3
+          # jvm=11 only latest 8.5 7 7.6 7.3 6 5 5.6
+          # jvm=8 only latest 8.5 7 7.6 7.3 6 5 5.6
+          # Resolve all values to actual value
+          # Remove duplicates (and alias runs)
+          if [ -z "${{ matrix.os }}" ]
+          then
+            echo "$0: matrix.os is not setup" 1>&2
+            exit 1
+          fi
+          if [ -z "${{ matrix.jvm }}" ]
+          then
+            echo "$0: matrix.jvm is not setup" 1>&2
+            exit 1
+          fi
+          if [ -z "${{ matrix.gradle }}" ]
+          then
+            echo "$0: matrix.gradle is not setup" 1>&2
+            exit 1
+          fi
+
+      - name: Gradle Version Setup
+        run: |
+          # 
+          curl -s "https://raw.githubusercontent.com/gradle/gradle/master/released-versions.json" > released-versions.json
+
+          # Only supporting 5.6 or newer
+          GRADLE_ALL_VERSIONS=$(jq '.finalReleases[].version' -r released-versions.json | sort -rn | tr '\n' ' ' | sed -e 's#\s5.5.1\s.*##')
+          echo "GRADLE_ALL_VERSIONS=$GRADLE_ALL_VERSIONS"
+
+          GRADLE_CANARY_VERSION=$(jq '.finalReleases[].version' -r released-versions.json | sort -rn | head -n1)
+          echo "GRADLE_CANARY_VERSION=$GRADLE_CANARY_VERSION"
+
+          GRADLE_CANARY_MAJOR=$(echo -n "$GRADLE_CANARY_VERSION" | cut -d '.' -f1)
+
+          regex_transform=$(echo -ne "${{ matrix.gradle }}" | sed -e 's#\.#\\\0#g')
+          GRADLE_MATRIX_VERSION=$(jq '.finalReleases[].version' -r released-versions.json | sort -rn | egrep -- "^${regex_transform}" | head -n1 | tr -d '\r\n')
+          echo "GRADLE_MATRIX_VERSION=$GRADLE_MATRIX_VERSION"
+
+          GRADLE_MATRIX_MAJOR=$(echo -n "$GRADLE_MATRIX_VERSION" | cut -d '.' -f1)
+
+          if gradlew -v || which gradlew
+          then
+            # confirm GHA didn't provide its own
+            echo "$0: ERROR ./gradlew appears to already be installed" 1>&2
+            exit 1
+          fi
+
+          if [ "${{ matrix.gradle }}" = "latest" ]
+          then
+            GRADLE_VERSION="$GRADLE_CANARY_VERSION"
+          else
+            GRADLE_VERSION="$GRADLE_MATRIX_VERSION"
+          fi
+          GRADLE_VERSION_MAJOR=$(echo -n "$GRADLE_VERSION" | cut -d '.' -f1)
+
+          # TODO disable duplicate runs which resolve to the same matrix versions
+          # latest 8 8.5 all resolve to 8.5 for example
+
+          echo "GRADLE_ALL_VERSIONS=$GRADLE_ALL_VERSIONS" >> $GITHUB_ENV
+          echo "GRADLE_CANARY_VERSION=$GRADLE_CANARY_VERSION" >> $GITHUB_ENV
+          echo "GRADLE_CANARY_MAJOR=$GRADLE_CANARY_MAJOR" >> $GITHUB_ENV
+          echo "GRADLE_MATRIX_VERSION=$GRADLE_MATRIX_VERSION" >> $GITHUB_ENV
+          echo "GRADLE_MATRIX_MAJOR=$GRADLE_MATRIX_MAJOR" >> $GITHUB_ENV
+          echo "GRADLE_VERSION=$GRADLE_VERSION" >> $GITHUB_ENV
+          echo "GRADLE_VERSION_MAJOR=$GRADLE_VERSION_MAJOR" >> $GITHUB_ENV
+
+          # Make the version so with wrapper edit
+          sed -e 's/^distributionUrl=/\#\0/' -i gradle/wrapper/gradle-wrapper.properties
+          echo "distributionUrl=https\://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-all.zip" >> gradle/wrapper/gradle-wrapper.properties
+
+          test -f gradle.properties
+          # Fixup gradle.properties based on Gradle major used to build
+          sed -e 's/^kotlinVersion=/\#\0/'   -i gradle.properties
+          sed -e 's/^testSetsVersion=/\#\0/' -i gradle.properties
+          case "$GRADLE_VERSION_MAJOR" in
+            5|6) echo "kotlinVersion=1.3.72"  >> gradle.properties
+                 echo "testSetsVersion=3.0.1" >> gradle.properties
+                 ;;
+            7)   echo "kotlinVersion=1.6.21"  >> gradle.properties
+                 echo "testSetsVersion=4.0.0" >> gradle.properties
+                 ;;
+            8|*) echo "kotlinVersion=1.9.20"  >> gradle.properties
+                 if [ "${{ matrix.jvm }}" = "8" ]
+                 then
+                   echo "testSetsVersion=4.0.0" >> gradle.properties
+                 else
+                   # Needs Java11+
+                   echo "testSetsVersion=4.1.0" >> gradle.properties
+                 fi
+                 ;;
+          esac
+          echo "### gradle.properties:"
+          cat gradle.properties
+
+      - name: Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.jvm }}
+
+      - name: Gradle - wrapper-validation-action
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Gradle - setup
+        uses: gradle/gradle-build-action@v2
+
+      - name: Show Diff
+        run: |
+          git diff || true
+
+      - name: Report Versions
+        run: |
+          # Print verbose diagnostics into logs
+          java -version
+
+          # download-artifact removes executable perm from files
+          test -x ./gradlew || chmod -c a+x ./gradlew
+          # Now run it
+          ./gradlew -v
+
+          JAVA_ARG_VERSION=$(java -version 2>&1 | sed -e ':a;N;$!ba;s/\n/<br>/g' -e 's#|#\\|#g')
+          JAVA_ARG_VERSION_SUMMARY=$(java -version 2>&1 | head -n1 | sed -e 's#openjdk\s\+##' -e 's#version\s\+##' -e 's#"##g' -e 's#\s\+.*$##')
+          GRADLE_ARG_VERSION=$(./gradlew -v 2>&1 | sed -e ':a;N;$!ba;s/\n/<br>/g' -e 's#|#\\|#g')
+
+          cat <<EOF >> /tmp/GITHUB_STEP_SUMMARY$$.txt
+          Gradle Version $GRADLE_VERSION (${{ matrix.gradle }})  JDK $JAVA_ARG_VERSION_SUMMARY (${{ matrix.jvm }})
+
+          | Package    | Details               |
+          | ---------- | --------------------- |
+          | Java       | ${JAVA_ARG_VERSION}   |
+          | Gradle     | ${GRADLE_ARG_VERSION} |
+          EOF
+
+          cat /tmp/GITHUB_STEP_SUMMARY$$.txt
+          cat /tmp/GITHUB_STEP_SUMMARY$$.txt >> $GITHUB_STEP_SUMMARY
+
+      - name: Gradle - dependencies
+        env: # to resolve artifacts from GH packages
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew $GRADLE_EXTRA_ARGS dependencies
+
+      - name: Gradle - check
+        run: |
+          if ! ./gradlew $GRADLE_EXTRA_ARGS check
+          then
+            ./gradlew $GRADLE_EXTRA_ARGS --stacktrace check
+          fi
+
+      - name: Gradle - integrationTest [${{env.GRADLE_VERSION}}]
+        if: ${{ vars.GRADLE_TARGET_ENABLE_integrationTest == 'true' || inputs.GRADLE_TARGET_ENABLE_integrationTest }}
+        run: ./gradlew $GRADLE_EXTRA_ARGS "-Dorg.unbrokendome.gradle.plugins.xjc.testutil.GradleVersions=${GRADLE_VERSION}" integrationTest
+
+      - name: Gradle - integrationTest [all]
+        if: ${{ vars.GRADLE_TARGET_ENABLE_integrationTest == 'true' || inputs.GRADLE_TARGET_ENABLE_integrationTest }}
+        run: ./gradlew $GRADLE_EXTRA_ARGS integrationTest
+
+      - name: Upload - prepare
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        shell: bash
+        run: |
+          mkdir dist
+          _build_repo_list=$(find . -type d -path "*/build/repo")
+          if [ -n "${_build_repo_list}" ]
+          then
+            for dir in ${_build_repo_list}
+            do
+              cp -a "$dir" "dist/"
+            done
+          else
+            echo "$0: no **/build/repo directories found" 1>&2
+          fi
+          find "dist" -type f -exec ls -ld {} \;
+          du -s "dist"
+
+          mkdir -p build/gh-pages
+          [ -d build/reports/tests  ] && cp -a build/reports/tests    build/gh-pages/
+          [ -d build/asciidoc/html5 ] && cp -a build/asciidoc/html5/* build/gh-pages/
+          [ -d build/dokka          ] && cp -a build/dokka            build/gh-pages/
+
+          mkdir -p build/gh-pages/maven2
+          [ -d "build/repo" ] && cp -a build/repo/* build/gh-pages/maven2/
+
+          ls -lad build/gh-pages
+          du -s build/gh-pages
+
+      - name: Upload - java${{ matrix.jvm }}-gradle${{ matrix.gradle }}-github-pages
+        uses: actions/upload-pages-artifact@main
+        if: false
+        with:
+          name: java${{ matrix.jvm }}-github-pages
+          path: build/gh-pages/
+          retention-days: 1
+
+      - name: Upload - perform
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        with:
+          name: java${{ matrix.jvm }}-gradle${{ matrix.gradle }}-${{ env.target_version }}-consume-artifacts
+          path: dist/repo/*
+          if-no-files-found: warn

--- a/.github/workflows/canary-consume.yml
+++ b/.github/workflows/canary-consume.yml
@@ -266,7 +266,7 @@ jobs:
           echo "target_artifact=$target_artifact" >> $GITHUB_ENV
           echo "target_version=$target_version" >> $GITHUB_ENV
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: java${{ env.GHA_INPUT_BUILD_JVM }}-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-build-artifacts
           path: .

--- a/.github/workflows/canary-consume.yml
+++ b/.github/workflows/canary-consume.yml
@@ -366,9 +366,13 @@ jobs:
             8|*) echo "kotlinVersion=1.9.20"  >> gradle.properties
                  if [ "${{ matrix.jvm }}" = "8" ]
                  then
-                   echo "testSetsVersion=4.0.0" >> gradle.properties
+                   # The official org.unbroken-dome.test-sets 4.1.0 Needs Java11+ and is the first version to support Gradle 8.x
+                   #echo "testSetsVersion=4.0.0" >> gradle.properties
+                   # So this is why this if[] exists, but the we now use unofficial:
+                   #org.darrylmiles.repack.org.unbroken-dome.test-sets which a release in Java8 bytecode of 4.1.0
+                   echo "testSetsVersion=4.1.0" >> gradle.properties
                  else
-                   # Needs Java11+
+                   # The official org.unbroken-dome.test-sets 4.1.0 Needs Java11+
                    echo "testSetsVersion=4.1.0" >> gradle.properties
                  fi
                  ;;

--- a/.github/workflows/canary-consume.yml
+++ b/.github/workflows/canary-consume.yml
@@ -151,8 +151,11 @@ jobs:
 
           mkdir -p build/gh-pages
           [ -d build/reports/tests  ] && cp -a build/reports/tests    build/gh-pages/
-          [ -d build/asciidoc/html5 ] && cp -a build/asciidoc/html5/* build/gh-pages/
-          [ -d build/dokka          ] && cp -a build/dokka            build/gh-pages/
+
+          docs_build_dir="build"
+          [ -d docs/build ] && docs_build_dir="docs/build" || true
+          [ -d $docs_build_dir/asciidoc/html5 ] && cp -a $docs_build_dir/asciidoc/html5/* build/gh-pages/
+          [ -d $docs_build_dir/dokka          ] && cp -a $docs_build_dir/dokka            build/gh-pages/
 
           mkdir -p build/gh-pages/maven2
           [ -d "build/repo" ] && cp -a build/repo/* build/gh-pages/maven2/
@@ -455,8 +458,11 @@ jobs:
 
           mkdir -p build/gh-pages
           [ -d build/reports/tests  ] && cp -a build/reports/tests    build/gh-pages/
-          [ -d build/asciidoc/html5 ] && cp -a build/asciidoc/html5/* build/gh-pages/
-          [ -d build/dokka          ] && cp -a build/dokka            build/gh-pages/
+
+          docs_build_dir="build"
+          [ -d docs/build ] && docs_build_dir="docs/build" || true
+          [ -d $docs_build_dir/asciidoc/html5 ] && cp -a $docs_build_dir/asciidoc/html5/* build/gh-pages/
+          [ -d $docs_build_dir/dokka          ] && cp -a $docs_build_dir/dokka            build/gh-pages/
 
           mkdir -p build/gh-pages/maven2
           [ -d "build/repo" ] && cp -a build/repo/* build/gh-pages/maven2/

--- a/.github/workflows/canary-consume.yml
+++ b/.github/workflows/canary-consume.yml
@@ -172,7 +172,7 @@ jobs:
           retention-days: 1
 
       - name: Upload - perform
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: true  # ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: java${{ env.GHA_INPUT_BUILD_JVM }}-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-build-artifacts
@@ -483,7 +483,7 @@ jobs:
           retention-days: 1
 
       - name: Upload - perform
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: java${{ matrix.jvm }}-gradle${{ matrix.gradle }}-${{ env.target_version }}-consume-artifacts

--- a/.github/workflows/canary-consume.yml
+++ b/.github/workflows/canary-consume.yml
@@ -64,7 +64,7 @@ jobs:
           echo "target_version=$target_version" >> $GITHUB_ENV
 
       - name: Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ env.GHA_INPUT_BUILD_JVM }}
@@ -381,7 +381,7 @@ jobs:
           cat gradle.properties
 
       - name: Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.jvm }}

--- a/.github/workflows/canary-consume.yml
+++ b/.github/workflows/canary-consume.yml
@@ -268,6 +268,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           name: java${{ env.GHA_INPUT_BUILD_JVM }}-${{ env.target_group }}-${{ env.target_artifact }}-${{ env.target_version }}-build-artifacts
           path: .
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,210 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - master
+  release:
+  workflow_dispatch:
+    inputs:
+      GITHUB_PACKAGES_PUBLISH:
+        description: 'Run publish Github Packages ?'
+        default: false
+        type: boolean
+      MAVEN_CENTRAL_PUBLISH:
+        description: 'Run publish Maven Central ?'
+        default: false
+        type: boolean
+      GAV_GROUP_ID:
+        description: 'GAV groupId ?'
+        default: org.darrylmiles.forked.org.unbroken-dome
+        type: string
+      GAV_VERSION:
+        description: 'GAV version ?'
+        default:
+        type: string
+      GRADLE_TARGET_integrationTest:
+        description: 'Run with integrationTest ?'
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    runs-on: [ubuntu-latest]
+
+    env:
+      GRADLE_EXTRA_ARGS: --no-daemon --warning-mode=all
+      JAVA_VERSION: 8
+      GRADLE_TARGET_integrationTest: false
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Validate inputs
+      env:
+        GRADLE_TARGET_integrationTest: ${{ inputs.GRADLE_TARGET_integrationTest }}
+        GITHUB_PACKAGES_PUBLISH: ${{ inputs.GITHUB_PACKAGES_PUBLISH }}
+        MAVEN_CENTRAL_PUBLISH: ${{ inputs.MAVEN_CENTRAL_PUBLISH }}
+        GAV_GROUP_ID: ${{ inputs.GAV_GROUP_ID }}
+        GAV_VERSION: ${{ inputs.GAV_VERSION }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+      run: |
+        # apply defaults for on.schedule
+        if [ -z "${GRADLE_TARGET_integrationTest}" ] && [ -n "${{ github.event.schedule }}" ]; then
+          # force this on for schedule build
+          # "${{ github.event.schedule }}" == "45 4 18 * *"
+          # $GITHUB_EVENT_NAME == "schedule"
+          echo "GRADLE_TARGET_integrationTest=true" >> $GITHUB_ENV
+        fi
+
+        # apply defaults for on.push
+        if [ -z "$GRADLE_TARGET_integrationTest" ]
+        then
+          GRADLE_TARGET_integrationTest=true
+          echo "GRADLE_TARGET_integrationTest=$GRADLE_TARGET_integrationTest (default)"
+        fi
+        if [ -z "$GITHUB_PACKAGES_PUBLISH" ]
+        then
+          GITHUB_PACKAGES_PUBLISH=false
+          echo "GITHUB_PACKAGES_PUBLISH=$GITHUB_PACKAGES_PUBLISH (default)"
+        fi
+        if [ -z "$MAVEN_CENTRAL_PUBLISH" ]
+        then
+          MAVEN_CENTRAL_PUBLISH=false
+          echo "MAVEN_CENTRAL_PUBLISH=$MAVEN_CENTRAL_PUBLISH (default)"
+        fi
+
+        # copy to env (as currently they maybe from inputs.* and need to be propagated)
+        if [ -n "$GRADLE_TARGET_integrationTest" ]
+        then
+          echo "GRADLE_TARGET_integrationTest=$GRADLE_TARGET_integrationTest" >> $GITHUB_ENV
+        fi
+        if [ -n "$GITHUB_PACKAGES_PUBLISH" ]
+        then
+          echo "GITHUB_PACKAGES_PUBLISH=$GITHUB_PACKAGES_PUBLISH" >> $GITHUB_ENV
+        fi
+        if [ -n "$MAVEN_CENTRAL_PUBLISH" ]
+        then
+          echo "MAVEN_CENTRAL_PUBLISH=$MAVEN_CENTRAL_PUBLISH" >> $GITHUB_ENV
+        fi
+
+        echo "GITHUB_PACKAGES_PUBLISH=$GITHUB_PACKAGES_PUBLISH"
+        echo "MAVEN_CENTRAL_PUBLISH=$MAVEN_CENTRAL_PUBLISH"
+        echo "GRADLE_TARGET_integrationTest=$GRADLE_TARGET_integrationTest"
+
+        # token check
+
+        # synchronize variable names with your build.gradle
+        if [ "$GITHUB_PACKAGES_PUBLISH" = "true" ]
+        then
+          if [ -z "$GITHUB_TOKEN" ]
+          then
+            echo "$0: GITHUB_TOKEN is not set" 1>&2
+            exit 1
+          fi
+          if [ -z "$GITHUB_ACTOR" ]
+          then
+            echo "$0: GITHUB_ACTOR is not set" 1>&2
+            exit 1
+          fi
+        fi
+
+        # synchronize variable names with your build.gradle
+        if [ "$MAVEN_CENTRAL_PUBLISH" = "true" ]
+        then
+          if [ -z "$MAVEN_PASSWORD" ]
+          then
+            echo "$0: MAVEN_PASSWORD is not set" 1>&2
+            exit 1
+          fi
+          if [ -z "$MAVEN_USERNAME" ]
+          then
+            echo "$0: MAVEN_USERNAME is not set" 1>&2
+            exit 1
+          fi
+        fi
+
+        if [ -n "$GAV_GROUP_ID" ]
+        then
+          sed -e 's/^\s*group\s*=\s*/#\0/' -i gradle.properties
+          echo "group=$GAV_GROUP_ID" >> gradle.properties
+          echo "GAV_GROUP_ID=$GAV_GROUP_ID"
+        fi
+
+        if [ -n "$GAV_VERSION" ]
+        then
+          sed -e 's/^\s*version\s*=\s*/#\0/' -i gradle.properties
+          echo "version=$GAV_VERSION" >> gradle.properties
+          echo "GAV_VERSION=$GAV_VERSION"
+        fi
+
+        git diff || true
+
+    - name: Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: ${{ env.JAVA_VERSION }}
+
+    - name: Gradle - wrapper-validation-action
+      uses: gradle/wrapper-validation-action@v1
+
+    - name: Gradle - setup
+      uses: gradle/gradle-build-action@v2
+
+    - name: Gradle - assemble
+      env: # to resolve artifacts from GH packages
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        ./gradlew $GRADLE_EXTRA_ARGS assemble
+
+    - name: Gradle - check
+      run: |
+        ./gradlew $GRADLE_EXTRA_ARGS check
+
+    - name: Gradle - integrationTest
+      if: ${{ env.GRADLE_TARGET_integrationTest != 'false' }}
+      run: |
+        ./gradlew $GRADLE_EXTRA_ARGS integrationTest
+
+    - name: Gradle - asciidoctor
+      run: |
+        ./gradlew $GRADLE_EXTRA_ARGS asciidoctor
+
+    - name: Gradle - dokka
+      run: |
+        ./gradlew $GRADLE_EXTRA_ARGS dokka
+
+    - name: Gradle - publish local
+      run: |
+        ./gradlew $GRADLE_EXTRA_ARGS publish
+        find build/repo || true
+
+    - name: Gradle - publish remote github packages
+      if: ${{ env.GITHUB_PACKAGES_PUBLISH == 'true' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        ./gradlew -PdoGitHubPackagesPublish=true $GRADLE_EXTRA_ARGS publish
+
+    - name: Gradle - publish remote maven central
+      if: ${{ env.MAVEN_CENTRAL_PUBLISH == 'true' }}
+      env:
+        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+      run: |
+        ./gradlew -PdoMavenCentralPublish=true $GRADLE_EXTRA_ARGS publish
+
+    - name: Upload - publish repo
+      uses: actions/upload-artifact@v3
+      with:
+        name: java${{ env.JAVA_VERSION }}-artifacts
+        path: build/repo/*
+        if-no-files-found: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -203,7 +203,7 @@ jobs:
         ./gradlew -PdoMavenCentralPublish=true $GRADLE_EXTRA_ARGS publish
 
     - name: Upload - publish repo
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: java${{ env.JAVA_VERSION }}-artifacts
         path: build/repo/*

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ dependency on the JAXB API:
 .build.gradle(.kts)
 ----
 plugins {
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
 }
 
 dependencies {

--- a/README.adoc
+++ b/README.adoc
@@ -108,7 +108,7 @@ endif::[]
 .build.gradle(.kts)
 ----
 plugins {
-    id("{maven-groupId}.xjc") version "2.1.0-SNAPSHOT"
+    id("{maven-groupId}.xjc") version "2.2.0-SNAPSHOT"
 }
 
 dependencies {

--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,7 @@ endif::[]
 :github-pages-uri: https://dlmiles.github.io/gradle-xjc-plugin
 :github-uri: https://github.com/dlmiles/gradle-xjc-plugin
 :github-m2-uri: https://maven.pkg.github.com/dlmiles/gradle-xjc-plugin
-:maven-groupId: io.github.dlmiles
+:maven-groupId: org.darrylmiles.forked.org.unbroken-dome
 :uri-build-status: https://github.com/dlmiles/gradle-xjc-plugin/actions/workflows/build.yml
 :img-build-status: https://github.com/dlmiles/gradle-xjc-plugin/actions/workflows/build.yml/badge.svg
 

--- a/README.adoc
+++ b/README.adoc
@@ -24,11 +24,20 @@ Invokes the `xjc` binding compiler from a Gradle build.
 
 == Features
 
-- Automatically enable XJC code generation for each source set in your project
-- support different versions of XJC through classpath isolation
-- producing and consuming episodes
-- catalogs with `maven:` and `classpath:` URI resolution (similar to maven-jaxb2-plugin)
-
+- Supports XJC Tool `com.sun.xml.bind` versions 2.1 (legacy), 2.2, 2.3, 2.4, 3.0 (jakarta) and
+  4.0 (jakarta) which is the reference implementation now hosted by Eclipse&reg; foundation
+  under the EE4J project.
+- Supports JAXB&trade; specification -target versions 2.0, 2.1, 2.2, 2.3, 3.0 (jakarta).
+- Automatically enable XJC code generation for each source set in your project.
+  Project structural use of multiple src/<name>/schema/ folders to organise bindings and
+  schemas.
+- Support XJC through classpath isolation to better control visibility of data presented to the
+  tool separate from the Gradle build itself.
+- Producing and consuming episodes.
+- Dependency based catalog sources with `maven:` and `classpath:` URI resolution (similar to
+  maven-jaxb2-plugin) as well as the standard file,jar,jar:file,http,https sources.
+- XJC tool plugin extention support, including custom plugins you may provide an implementation
+  for.
 
 == Requirements
 

--- a/README.adoc
+++ b/README.adoc
@@ -5,6 +5,14 @@ ifdef::env-github[]
 :caution-caption: :fire:
 :warning-caption: :warning:
 endif::[]
+:my-base-uri: https://github.com/dlmiles/gradle-xjc-plugin
+:uri-build-status: https://github.com/dlmiles/gradle-xjc-plugin/actions/workflows/build.yml
+:img-build-status: https://github.com/dlmiles/gradle-xjc-plugin/actions/workflows/build.yml/badge.svg
+
+ifdef::env-github[]
+image:{img-build-status}[CI-Gradle-build,link={uri-build-status}]
+#CI Targets: `Java 8` and `Java 11` with `Gradle 5.6` through `Gradle 8.0.2`#
+endif::[]
 
 = Gradle XJC Plugin
 

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,10 @@ ifdef::env-github[]
 :caution-caption: :fire:
 :warning-caption: :warning:
 endif::[]
-:my-base-uri: https://github.com/dlmiles/gradle-xjc-plugin
+:github-pages-uri: https://dlmiles.github.io/gradle-xjc-plugin
+:github-uri: https://github.com/dlmiles/gradle-xjc-plugin
+:github-m2-uri: https://maven.pkg.github.com/dlmiles/gradle-xjc-plugin
+:maven-groupId: io.github.dlmiles
 :uri-build-status: https://github.com/dlmiles/gradle-xjc-plugin/actions/workflows/build.yml
 :img-build-status: https://github.com/dlmiles/gradle-xjc-plugin/actions/workflows/build.yml/badge.svg
 
@@ -29,8 +32,20 @@ Invokes the `xjc` binding compiler from a Gradle build.
 
 == Requirements
 
+The Gradle plugin itself:
+
 - Gradle 5.6 or higher
 - JDK 1.8 or higher (when running Gradle)
+
+The XJC Tool requirements:
+
+- If using XJC Tool 4.x or later, the XJC Tool requires JDK 11 or higher while this
+  plugin only requires 1.8 or higher, earlier versions of XJC Tool are
+  compatible with JDK 1.8
+- Some specific XJC Tool versions may have been published with incorrect byte code
+  compatibility, resulting in those versions not running on the Java SE version they
+  intended to target
+- See section link:{github-pages-uri}#_xjc_tool_runtime_java_compatibility[XJC Tool Runtime Java Compatibility]
 
 
 == Quick Start
@@ -38,6 +53,33 @@ Invokes the `xjc` binding compiler from a Gradle build.
 Apply the `org.unbroken-dome.xjc` plugin to your Gradle build script and add an appropriate
 dependency on the JAXB API:
 
+ifdef::env-github[]
+[source,kotlin,subs="attributes+"]
+.settings.gradle(.kts)
+----
+pluginManagement {
+    // 3rd party releases and SNAPSHOTs
+    maven {
+        url "{github-pages-uri}/java8/maven2"
+        // url "{github-m2-uri}"
+        content {
+            // this repository *only* contains artifacts for specific groups
+            includeGroup "org.unbroken-dome.xjc"
+            includeGroup "org.unbroken-dome.gradle-plugins"
+ifdef::env-github[]
+
+            includeGroup "{maven-groupId}.xjc"
+            includeGroup "{maven-groupId}.gradle-plugins"
+endif::[]
+        }
+    }
+
+    // Official releases only
+    gradlePluginPortal()   
+}
+----
+
+endif::[]
 [source,kotlin]
 .build.gradle(.kts)
 ----
@@ -59,5 +101,11 @@ it the `main` Java compilation.
 
 == Further Documentation
 
-* https://unbroken-dome.github.io/projects/gradle-xjc-plugin/[User Manual]
-* https://unbroken-dome.github.io/projects/gradle-xjc-plugin/dokka/gradle-xjc-plugin/[API/DSL Documentation]
+* {github-pages-uri}/[User Manual]
+* {github-pages-uri}/dokka/gradle-xjc-plugin/[API/DSL Documentation]
+* {github-m2-uri}/[Github Maven2 Package Browse]
+* {github-pages-uri}/java8/maven2/[Github-Pages Maven2 Artifact Browse]
+* {github-pages-uri}/artifacts/[Maven2 Artifact Archive Download]
+
+* {github-pages-uri}/java8/tests/[Java 8 Test Reports]
+* {github-pages-uri}/java11/tests/[Java 11 Test Reports]

--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,12 @@ endif::[]
 
 ifdef::env-github[]
 image:{img-build-status}[CI-Gradle-build,link={uri-build-status}]
-#CI Targets: `Java 8` and `Java 11` with `Gradle 5.6` through `Gradle 8.0.2`#
+
+#CI Targets: `Java 8` and `Java 11` for plugin project builder#
+
+#Plugin artifact supports `Java 8`, `Java 11`, `Java 17` and `Java 21`#
+
+#For use with `Gradle 5.6` through `Gradle 8.5`#
 endif::[]
 
 = Gradle XJC Plugin
@@ -36,15 +41,19 @@ Invokes the `xjc` binding compiler from a Gradle build.
 - Producing and consuming episodes.
 - Dependency based catalog sources with `maven:` and `classpath:` URI resolution (similar to
   maven-jaxb2-plugin) as well as the standard file,jar,jar:file,http,https sources.
-- XJC tool plugin extention support, including custom plugins you may provide an implementation
+- XJC tool plugin extension support, including custom plugins you may provide an implementation
   for.
 
 == Requirements
 
 The Gradle plugin itself:
 
-- Gradle 5.6 or higher
+- Gradle 5.6 or higher including
+* 5.6 or later using JDK8 or JDK11
+* 7.3 or later using JDK8, JDK11 or JDK17
+* 8.5 or later using JDK8, JDK11, JDK17 or JDK21
 - JDK 1.8 or higher (when running Gradle)
+- See also Gradle build tool Java compatibility matrix at https://docs.gradle.org/current/userguide/compatibility.html for which this plugin is consistent with
 
 The XJC Tool requirements:
 
@@ -59,7 +68,7 @@ The XJC Tool requirements:
 
 == Quick Start
 
-Apply the `org.unbroken-dome.xjc` plugin to your Gradle build script and add an appropriate
+Apply the `{maven-groupId}.xjc` plugin to your Gradle build script and add an appropriate
 dependency on the JAXB API:
 
 ifdef::env-github[]
@@ -67,19 +76,25 @@ ifdef::env-github[]
 .settings.gradle(.kts)
 ----
 pluginManagement {
-    // 3rd party releases and SNAPSHOTs
-    maven {
-        url "{github-pages-uri}/java8/maven2"
-        // url "{github-m2-uri}"
-        content {
-            // this repository *only* contains artifacts for specific groups
-            includeGroup "org.unbroken-dome.xjc"
-            includeGroup "org.unbroken-dome.gradle-plugins"
+    repositories {
+        maven {
+            //url = uri("{github-pages-uri}/java8/maven2")
+            url = uri("{github-m2-uri}")
+            content {
+                // this repository *only* contains artifacts for specific groups
+                includeGroup("org.unbroken-dome.xjc")
+                includeGroup("org.unbroken-dome")
 ifdef::env-github[]
 
-            includeGroup "{maven-groupId}.xjc"
-            includeGroup "{maven-groupId}.gradle-plugins"
+                includeGroup("{maven-groupId}.xjc")
+                includeGroup("{maven-groupId}")
 endif::[]
+            }
+            credentials {
+                // github requires any valid credentials even to GET packages
+                username = System.getenv("GITHUB_USERNAME")
+                password = System.getenv("GITHUB_TOKEN")
+            }
         }
     }
 
@@ -89,11 +104,11 @@ endif::[]
 ----
 
 endif::[]
-[source,kotlin]
+[source,kotlin,subs="normal"]
 .build.gradle(.kts)
 ----
 plugins {
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("{maven-groupId}.xjc") version "2.1.0-SNAPSHOT"
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,6 @@ plugins {
     `maven-publish`
     id("org.unbroken-dome.test-sets") // version "$testSetsVersion"
     id("com.gradle.plugin-publish") version "0.21.0"
-    id("org.asciidoctor.convert") version "2.4.0"
-    id("org.jetbrains.dokka") version "0.10.1"
 }
 
 
@@ -227,51 +225,6 @@ pluginBundle {
 }
 
 
-tasks.named("dokka", org.jetbrains.dokka.gradle.DokkaTask::class) {
-    outputFormat = "html"
-    configuration {
-        externalDocumentationLink {
-            url = uri("https://docs.gradle.org/current/javadoc/").toURL()
-        }
-        reportUndocumented = false
-        sourceLink {
-            path = "src/main/kotlin"
-            url = "https://github.com/${githubRepositoryOwner}/gradle-xjc-plugin/blob/v${project.version}/src/main/kotlin"
-            lineSuffix = "#L"
-        }
-        perPackageOption {
-            prefix = "org.unbrokendome.gradle.plugins.xjc.internal"
-            suppress = true
-        }
-    }
-}
-
-
-asciidoctorj {
-    version = "2.4.1"
-}
-
-dependencies {
-    "asciidoctor"("com.bmuschko:asciidoctorj-tabbed-code-extension:0.3")
-}
-
-
-tasks.named("asciidoctor", org.asciidoctor.gradle.AsciidoctorTask::class) {
-    sourceDir("docs")
-    sources(delegateClosureOf<PatternSet> { include("index.adoc") })
-
-    options(mapOf(
-        "doctype" to "book"
-    ))
-    attributes(mapOf(
-        "GITHUB_REPOSITORY_OWNER" to githubRepositoryOwner,
-        "github-pages-uri" to "https://${githubRepositoryOwner}.github.io/gradle-xjc-plugin",
-        "github-uri" to "https://github.com/${githubRepositoryOwner}/gradle-xjc-plugin",
-        "project-version" to project.version,
-        "source-highlighter" to "prettify"
-    ))
-}
-
 apply {
-     from("${rootDir}/publish.gradle.kts")
+    from("${rootDir}/publish.gradle.kts")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm")
     `java-gradle-plugin`
     `maven-publish`
-    id("org.unbroken-dome.test-sets") version "4.0.0"
+    id("org.unbroken-dome.test-sets") // version "$testSetsVersion"
     id("com.gradle.plugin-publish") version "0.21.0"
     id("org.asciidoctor.convert") version "2.4.0"
     id("org.jetbrains.dokka") version "0.10.1"
@@ -10,6 +10,7 @@ plugins {
 
 
 val kotlinVersion: String by extra
+val testSetsVersion: String by extra
 
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -128,6 +128,12 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions.freeCompilerArgs = listOf("-Xjvm-default=enable")
 }
 
+// There is no *.java code in this project but newer Gradle complains if there
+// is a mismatch with kotlin due to the runtime JDK being newer than kotlin target.
+tasks.withType<JavaCompile> {
+    targetCompatibility = "1.8"
+}
+
 
 tasks.named<Jar>("jar") {
     for (xjcSourceSet in xjcSourceSets) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,6 +101,7 @@ dependencies {
     "xjc40CompileOnly"("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
 
     "testLibApi"(kotlin("stdlib-jdk8"))
+    // Bumping past 0.22 forces kotlin 1.4.x (Gradle 7+)
     "testLibApi"("com.willowtreeapps.assertk:assertk-jvm:0.22")
 
     // Bumping these past 2.0.15 forces Gradle 7.x use for newer kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,8 +48,19 @@ dependencies {
 
     for (xjcSourceSet in xjcSourceSets) {
         (xjcSourceSet.compileOnlyConfigurationName)(sourceSets["main"].output)
-        (xjcSourceSet.compileOnlyConfigurationName)(configurations["compileOnly"])
-        (xjcSourceSet.implementationConfigurationName)(configurations["implementation"])
+
+        // Gradle 8.x does not allow referencing configurations[] like this anymore
+        // but it seems a convenience to unroll the deplist
+
+        // for compileOnly()
+        //(xjcSourceSet.compileOnlyConfigurationName)(configurations["compileOnly"].allDependencies)
+        (xjcSourceSet.compileOnlyConfigurationName)(kotlin("stdlib-jdk8"))
+        (xjcSourceSet.compileOnlyConfigurationName)(gradleApi())
+
+        // for implementation()
+        //(xjcSourceSet.implementationConfigurationName)(configurations["implementation"].allDependencies)
+        (xjcSourceSet.implementationConfigurationName)("javax.activation:javax.activation-api:1.2.0")
+        (xjcSourceSet.implementationConfigurationName)("xml-resolver:xml-resolver:1.2")
     }
 
     "xjcCommonCompileOnly"("com.sun.xml.bind:jaxb-xjc:2.3.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,7 +99,7 @@ dependencies {
     "integrationTestImplementation"(gradleTestKit())
     "integrationTestImplementation"("org.junit.jupiter:junit-jupiter-api:5.7.0")
     "integrationTestImplementation"("org.junit.platform:junit-platform-commons:1.7.0")
-    "integrationTestImplementation"("org.ow2.asm:asm:9.4")
+    "integrationTestImplementation"("org.ow2.asm:asm:9.5")
     "integrationTestRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine:5.7.0")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -229,3 +229,7 @@ tasks.named("asciidoctor", org.asciidoctor.gradle.AsciidoctorTask::class) {
         "source-highlighter" to "prettify"
     ))
 }
+
+apply {
+     from("${rootDir}/publish.gradle.kts")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,9 +62,10 @@ dependencies {
     "xjc23CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.3.3")
 
     "xjc30CompileOnly"(xjcCommon.output)
-    "xjc30CompileOnly"("com.sun.xml.bind:jaxb-xjc:3.0.0-M4")
-    "xjc30CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.3.3")
-    "xjc30CompileOnly"("jakarta.xml.bind:jakarta.xml.bind-api:3.0.0-RC3")
+    "xjc30CompileOnly"("com.sun.xml.bind:jaxb-xjc:3.0.2")
+    "xjc30CompileOnly"("com.sun.xml.bind:jaxb-core:3.0.2")
+    "xjc30CompileOnly"("com.sun.xml.bind:jaxb-impl:3.0.2")
+    "xjc30CompileOnly"("jakarta.xml.bind:jakarta.xml.bind-api:3.0.1")
 
     "testLibApi"(kotlin("stdlib-jdk8"))
     "testLibApi"("com.willowtreeapps.assertk:assertk-jvm:0.22")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm")
     `java-gradle-plugin`
     `maven-publish`
-    id("org.unbroken-dome.test-sets") version "3.0.1"
+    id("org.unbroken-dome.test-sets") version "4.0.0"
     id("com.gradle.plugin-publish") version "0.21.0"
     id("org.asciidoctor.convert") version "2.4.0"
     id("org.jetbrains.dokka") version "0.10.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,8 +33,9 @@ testSets {
 val xjcCommon: SourceSet by sourceSets.creating
 val xjc22: SourceSet by sourceSets.creating
 val xjc23: SourceSet by sourceSets.creating
+val xjc24: SourceSet by sourceSets.creating
 val xjc30: SourceSet by sourceSets.creating
-val xjcSourceSets = listOf(xjcCommon, xjc22, xjc23, xjc30)
+val xjcSourceSets = listOf(xjcCommon, xjc22, xjc23, xjc24, xjc30)
 
 
 dependencies {
@@ -60,6 +61,11 @@ dependencies {
 
     "xjc23CompileOnly"(xjcCommon.output)
     "xjc23CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.3.3")
+
+    "xjc24CompileOnly"(xjcCommon.output)
+    "xjc24CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.4.0-b180830.0438")
+    "xjc24CompileOnly"("com.sun.xml.bind:jaxb-impl:2.4.0-b180830.0438")
+    "xjc22CompileOnly"("javax.xml.bind:jaxb-api:2.4.0-b180830.0359")
 
     "xjc30CompileOnly"(xjcCommon.output)
     "xjc30CompileOnly"("com.sun.xml.bind:jaxb-xjc:3.0.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,10 @@ dependencies {
     "testLibApi"(kotlin("stdlib-jdk8"))
     "testLibApi"("com.willowtreeapps.assertk:assertk-jvm:0.22")
 
-    "testImplementation"("org.spekframework.spek2:spek-dsl-jvm:2.0.9")
+    // Bumping these past 2.0.15 forces Gradle 7.x use for newer kotlin
+    "testImplementation"("org.spekframework.spek2:spek-dsl-jvm:2.0.15")
+    // 2.0.16 requires Java11 runtime, 2.0.17 reverted back to Java8
+    // But needs Gradle 7.x kotlin
     "testRuntimeOnly"("org.spekframework.spek2:spek-runner-junit5:2.0.15")
 
     "integrationTestImplementation"(gradleTestKit())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,10 @@ dependencies {
     "xjc22CompileOnly"("javax.xml.bind:jaxb-api:2.2.11")
 
     "xjc23CompileOnly"(xjcCommon.output)
-    "xjc23CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.3.3")
+    "xjc23CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.3.8")
+    "xjc23CompileOnly"("com.sun.xml.bind:jaxb-core:2.3.0.1")
+    "xjc23CompileOnly"("com.sun.xml.bind:jaxb-impl:2.3.8")
+    "xjc23CompileOnly"("javax.xml.bind:jaxb-api:2.3.1")
 
     "xjc24CompileOnly"(xjcCommon.output)
     "xjc24CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.4.0-b180830.0438")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     `maven-publish`
     id("org.unbroken-dome.test-sets") version "3.0.1"
     id("com.gradle.plugin-publish") version "0.12.0"
-    id("org.asciidoctor.convert") version "1.5.9.2"
+    id("org.asciidoctor.convert") version "2.4.0"
     id("org.jetbrains.dokka") version "0.10.1"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,12 +31,13 @@ testSets {
 
 
 val xjcCommon: SourceSet by sourceSets.creating
+val xjc21: SourceSet by sourceSets.creating
 val xjc22: SourceSet by sourceSets.creating
 val xjc23: SourceSet by sourceSets.creating
 val xjc24: SourceSet by sourceSets.creating
 val xjc30: SourceSet by sourceSets.creating
 val xjc40: SourceSet by sourceSets.creating
-val xjcSourceSets = listOf(xjcCommon, xjc22, xjc23, xjc24, xjc30, xjc40)
+val xjcSourceSets = listOf(xjcCommon, xjc21, xjc22, xjc23, xjc24, xjc30, xjc40)
 
 
 dependencies {
@@ -53,6 +54,12 @@ dependencies {
     }
 
     "xjcCommonCompileOnly"("com.sun.xml.bind:jaxb-xjc:2.3.3")
+
+    "xjc21CompileOnly"(xjcCommon.output)
+    "xjc21CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.1.17")
+    "xjc21CompileOnly"("com.sun.xml.bind:jaxb-core:2.1.14")
+    "xjc21CompileOnly"("com.sun.xml.bind:jaxb-impl:2.1.17")
+    "xjc21CompileOnly"("javax.xml.bind:jaxb-api:2.1")
 
     "xjc22CompileOnly"(xjcCommon.output)
     "xjc22CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.2.11")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ val kotlinVersion: String by extra
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     `java-gradle-plugin`
     `maven-publish`
     id("org.unbroken-dome.test-sets") version "3.0.1"
-    id("com.gradle.plugin-publish") version "0.12.0"
+    id("com.gradle.plugin-publish") version "0.21.0"
     id("org.asciidoctor.convert") version "2.4.0"
     id("org.jetbrains.dokka") version "0.10.1"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,7 @@ dependencies {
     "testLibApi"("com.willowtreeapps.assertk:assertk-jvm:0.22")
 
     "testImplementation"("org.spekframework.spek2:spek-dsl-jvm:2.0.9")
-    "testRuntimeOnly"("org.spekframework.spek2:spek-runner-junit5:2.0.9")
+    "testRuntimeOnly"("org.spekframework.spek2:spek-runner-junit5:2.0.15")
 
     "integrationTestImplementation"(gradleTestKit())
     "integrationTestImplementation"("org.junit.jupiter:junit-jupiter-api:5.7.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,10 +95,10 @@ dependencies {
     "xjc30CompileOnly"("jakarta.xml.bind:jakarta.xml.bind-api:3.0.1")
 
     "xjc40CompileOnly"(xjcCommon.output)
-    "xjc40CompileOnly"("com.sun.xml.bind:jaxb-xjc:4.0.2")
-    "xjc40CompileOnly"("com.sun.xml.bind:jaxb-core:4.0.2")
-    "xjc40CompileOnly"("com.sun.xml.bind:jaxb-impl:4.0.2")
-    "xjc40CompileOnly"("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
+    "xjc40CompileOnly"("com.sun.xml.bind:jaxb-xjc:4.0.4")
+    "xjc40CompileOnly"("com.sun.xml.bind:jaxb-core:4.0.4")
+    "xjc40CompileOnly"("com.sun.xml.bind:jaxb-impl:4.0.4")
+    "xjc40CompileOnly"("jakarta.xml.bind:jakarta.xml.bind-api:4.0.1")
 
     "testLibApi"(kotlin("stdlib-jdk8"))
     // Bumping past 0.22 forces kotlin 1.4.x (Gradle 7+)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,8 @@ val xjc22: SourceSet by sourceSets.creating
 val xjc23: SourceSet by sourceSets.creating
 val xjc24: SourceSet by sourceSets.creating
 val xjc30: SourceSet by sourceSets.creating
-val xjcSourceSets = listOf(xjcCommon, xjc22, xjc23, xjc24, xjc30)
+val xjc40: SourceSet by sourceSets.creating
+val xjcSourceSets = listOf(xjcCommon, xjc22, xjc23, xjc24, xjc30, xjc40)
 
 
 dependencies {
@@ -75,6 +76,12 @@ dependencies {
     "xjc30CompileOnly"("com.sun.xml.bind:jaxb-core:3.0.2")
     "xjc30CompileOnly"("com.sun.xml.bind:jaxb-impl:3.0.2")
     "xjc30CompileOnly"("jakarta.xml.bind:jakarta.xml.bind-api:3.0.1")
+
+    "xjc40CompileOnly"(xjcCommon.output)
+    "xjc40CompileOnly"("com.sun.xml.bind:jaxb-xjc:4.0.2")
+    "xjc40CompileOnly"("com.sun.xml.bind:jaxb-core:4.0.2")
+    "xjc40CompileOnly"("com.sun.xml.bind:jaxb-impl:4.0.2")
+    "xjc40CompileOnly"("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
 
     "testLibApi"(kotlin("stdlib-jdk8"))
     "testLibApi"("com.willowtreeapps.assertk:assertk-jvm:0.22")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,7 +99,7 @@ dependencies {
     "integrationTestImplementation"(gradleTestKit())
     "integrationTestImplementation"("org.junit.jupiter:junit-jupiter-api:5.7.0")
     "integrationTestImplementation"("org.junit.platform:junit-platform-commons:1.7.0")
-    "integrationTestImplementation"("org.ow2.asm:asm:9.0")
+    "integrationTestImplementation"("org.ow2.asm:asm:9.4")
     "integrationTestRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine:5.7.0")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,9 +78,9 @@ dependencies {
     "xjc22CompileOnly"("javax.xml.bind:jaxb-api:2.2.11")
 
     "xjc23CompileOnly"(xjcCommon.output)
-    "xjc23CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.3.8")
+    "xjc23CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.3.9")
     "xjc23CompileOnly"("com.sun.xml.bind:jaxb-core:2.3.0.1")
-    "xjc23CompileOnly"("com.sun.xml.bind:jaxb-impl:2.3.8")
+    "xjc23CompileOnly"("com.sun.xml.bind:jaxb-impl:2.3.9")
     "xjc23CompileOnly"("javax.xml.bind:jaxb-api:2.3.1")
 
     "xjc24CompileOnly"(xjcCommon.output)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm")
     `java-gradle-plugin`
     `maven-publish`
-    id("org.unbroken-dome.test-sets") // version "$testSetsVersion"
+    id("org.darrylmiles.repack.org.unbroken-dome.test-sets") // version "$testSetsVersion"
     id("com.gradle.plugin-publish") version "0.21.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -125,7 +125,11 @@ configurations.all {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
-    kotlinOptions.freeCompilerArgs = listOf("-Xjvm-default=enable")
+    if(kotlinVersion >= "1.6.20") {
+        kotlinOptions.freeCompilerArgs = listOf("-Xjvm-default=all-compatibility")
+    } else {
+        kotlinOptions.freeCompilerArgs = listOf("-Xjvm-default=enable") // 1.3 thru 1.6.0 (not 1.6.20)
+    }
 }
 
 // There is no *.java code in this project but newer Gradle complains if there

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,9 +198,18 @@ gradlePlugin {
 }
 
 
+fun resolveSystemGetenv(name: String, defaultValue: String? = null): String? {
+    if(System.getenv().containsKey(name))
+        return System.getenv(name)
+    return defaultValue
+}
+
+val githubRepositoryOwner = resolveSystemGetenv("GITHUB_REPOSITORY_OWNER", "unbroken-dome")
+
+
 pluginBundle {
-    website = "https://github.com/unbroken-dome/gradle-xjc-plugin"
-    vcsUrl = "https://github.com/unbroken-dome/gradle-xjc-plugin"
+    website = "https://github.com/${githubRepositoryOwner}/gradle-xjc-plugin"
+    vcsUrl = "https://github.com/${githubRepositoryOwner}/gradle-xjc-plugin"
     description = "A plugin that integrates the XJC binding compiler into a Gradle build."
     tags = listOf("xjc", "jaxb", "code generation", "xml")
 
@@ -221,7 +230,7 @@ tasks.named("dokka", org.jetbrains.dokka.gradle.DokkaTask::class) {
         reportUndocumented = false
         sourceLink {
             path = "src/main/kotlin"
-            url = "https://github.com/unbroken-dome/gradle-xjc-plugin/blob/v${project.version}/src/main/kotlin"
+            url = "https://github.com/${githubRepositoryOwner}/gradle-xjc-plugin/blob/v${project.version}/src/main/kotlin"
             lineSuffix = "#L"
         }
         perPackageOption {
@@ -249,6 +258,9 @@ tasks.named("asciidoctor", org.asciidoctor.gradle.AsciidoctorTask::class) {
         "doctype" to "book"
     ))
     attributes(mapOf(
+        "GITHUB_REPOSITORY_OWNER" to githubRepositoryOwner,
+        "github-pages-uri" to "https://${githubRepositoryOwner}.github.io/gradle-xjc-plugin",
+        "github-uri" to "https://github.com/${githubRepositoryOwner}/gradle-xjc-plugin",
         "project-version" to project.version,
         "source-highlighter" to "prettify"
     ))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,6 +142,11 @@ tasks.withType<Test> {
     doFirst {
         project.mkdir(tmpDir)
     }
+
+    // ensure custom system properties are exposed to testing from CI
+    System.getProperties().filter { it.key.toString().startsWith("org.unbrokendome.gradle.plugins.xjc") }
+        .forEach { (t, u) -> systemProperty(t.toString(), u ?: "") }
+
 }
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
     "xjc24CompileOnly"(xjcCommon.output)
     "xjc24CompileOnly"("com.sun.xml.bind:jaxb-xjc:2.4.0-b180830.0438")
     "xjc24CompileOnly"("com.sun.xml.bind:jaxb-impl:2.4.0-b180830.0438")
-    "xjc22CompileOnly"("javax.xml.bind:jaxb-api:2.4.0-b180830.0359")
+    "xjc24CompileOnly"("javax.xml.bind:jaxb-api:2.4.0-b180830.0359")
 
     "xjc30CompileOnly"(xjcCommon.output)
     "xjc30CompileOnly"("com.sun.xml.bind:jaxb-xjc:3.0.2")

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -1,0 +1,72 @@
+import org.jetbrains.dokka.gradle.DokkaTask
+import org.asciidoctor.gradle.AsciidoctorTask
+
+plugins {
+    kotlin("jvm")
+    id("org.asciidoctor.convert") version "2.4.0"
+    id("org.jetbrains.dokka") version "0.10.1"
+}
+
+val kotlinVersion: String by extra
+
+
+repositories {
+    mavenCentral()
+}
+
+
+fun resolveSystemGetenv(name: String, defaultValue: String? = null): String? {
+    if(System.getenv().containsKey(name))
+        return System.getenv(name)
+    return defaultValue
+}
+
+val githubRepositoryOwner = resolveSystemGetenv("GITHUB_REPOSITORY_OWNER", "unbroken-dome")
+
+
+tasks.named("dokka", org.jetbrains.dokka.gradle.DokkaTask::class) {
+//tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
+    outputFormat = "html"
+    configuration {
+        externalDocumentationLink {
+            url = uri("https://docs.gradle.org/current/javadoc/").toURL()
+        }
+        reportUndocumented = false
+        sourceLink {
+            path = "src/main/kotlin"
+            url = "https://github.com/${githubRepositoryOwner}/gradle-xjc-plugin/blob/v${project.version}/src/main/kotlin"
+            lineSuffix = "#L"
+        }
+        perPackageOption {
+            prefix = "org.unbrokendome.gradle.plugins.xjc.internal"
+            suppress = true
+        }
+    }
+}
+
+
+asciidoctorj {
+    version = "2.4.1"
+}
+
+dependencies {
+    "asciidoctor"("com.bmuschko:asciidoctorj-tabbed-code-extension:0.3")
+}
+
+
+tasks.named("asciidoctor", org.asciidoctor.gradle.AsciidoctorTask::class) {
+//tasks.withType<org.asciidoctor.gradle.AsciidoctorTask>().configureEach {
+    sourceDir(".")
+    sources(delegateClosureOf<PatternSet> { include("index.adoc") })
+
+    options(mapOf(
+        "doctype" to "book"
+    ))
+    attributes(mapOf(
+        "GITHUB_REPOSITORY_OWNER" to githubRepositoryOwner,
+        "github-pages-uri" to "https://${githubRepositoryOwner}.github.io/gradle-xjc-plugin",
+        "github-uri" to "https://github.com/${githubRepositoryOwner}/gradle-xjc-plugin",
+        "project-version" to project.version,
+        "source-highlighter" to "prettify"
+    ))
+}

--- a/docs/controlling-xjc-behavior.adoc
+++ b/docs/controlling-xjc-behavior.adoc
@@ -170,6 +170,53 @@ TIP: When expecting `jarkarta` package output, ensure to remove `javax.xml.bind:
 |===
 
 
+== XJC Tool runtime Java compatibility
+
+This table maybe a useful reference, this only concerns the standard `com.sun.xml.bind`
+implementation and the contents of the jaxb-xjc.jar itself.
+
+Inaccuracies may exist in this table, but it demonstrates some possible unexpected
+inconsistencies to look into when working with some versions of the XJC tool.
+
+
+|===
+| XJC Tool Version | Java Version
+
+| 2.1
+| Java SE 5
+
+| 2.2 to 2.2.5
+| Java SE 5
+
+| 2.2.6+
+| Java SE 6
+
+| 2.3.0-b170127.1453 and 2.3.0.1
+| Java SE 7 (JDK6+ com/sun/xml/dtdparser/*.class, no JDK9+ module-info.class provided but JDK9+ Options.class)
+
+| 2.3.0
+| Java SE 7 (JDK6+ com/sun/xml/dtdparser/*.class, no JDK9+ module-info.class provided but XJC2Task/CatalogUtil still provided)
+
+| 2.3.1
+| Java SE 7 (JDK9+ module-info.class provided)
+
+| 2.3.2
+| Java SE 7 (removed JDK9+ module-info.class but XJC2Task/CatalogUtil still provided)
+
+| 2.3.3+
+| Java SE 8 (JDK9+ module-info.class provided)
+
+| 2.4.x
+| Java SE 7 (JDK8+ com/sun/xml/dtdparser/*.class, JDK9+ module-info.class provided)
+
+| 3.x
+| Java SE 8 (JDK9+ module-info.class provided)
+
+| 4.x
+| Java SE 11
+
+|===
+
 == Configuring XJC with Gradle Project Properties
 
 As an alternative to configuring the above settings in your build script, you can use Gradle project

--- a/docs/controlling-xjc-behavior.adoc
+++ b/docs/controlling-xjc-behavior.adoc
@@ -15,7 +15,7 @@ The following properties are available in the project-scoped `xjc` block, and ap
 | `-target`
 | (use latest version)
 
-| `docLocale` (`java.util.Locale`)
+| `docLocale` (`String`)
 | The locale to be used when running XJC. This may influence the language of documentation comments in XJC-generated files.
 | (no equivalent)
 | JVM default locale

--- a/docs/controlling-xjc-behavior.adoc
+++ b/docs/controlling-xjc-behavior.adoc
@@ -21,7 +21,7 @@ The following properties are available in the project-scoped `xjc` block, and ap
 | JVM default locale
 
 | `encoding` (`String`)
-| The encoding for generated files.
+| The encoding for generated files.  This is supported by XJC 2.2 and later.
 | `-encoding` (non-standard)
 | `UTF-8`
 

--- a/docs/controlling-xjc-behavior.adoc
+++ b/docs/controlling-xjc-behavior.adoc
@@ -15,7 +15,7 @@ The following properties are available in the project-scoped `xjc` block, and ap
 | `targetVersion` (`String`)
 | The version of the JAXB specification to target.
 | `-target`
-| (use latest version)
+| (use latest version supported by the XJC tool version in use)
 
 | `docLocale` (`String`)
 | The locale to be used when running XJC. This may influence the language of documentation comments in XJC-generated files.

--- a/docs/controlling-xjc-behavior.adoc
+++ b/docs/controlling-xjc-behavior.adoc
@@ -4,6 +4,8 @@ The link:https://docs.oracle.com/javase/8/docs/technotes/tools/unix/xjc.html[com
 a number of arguments to fine-tune the code generation. The XJC Gradle plugin supports many of these as properties
 which can be set in the build script.
 
+The link:https://eclipse-ee4j.github.io/jaxb-ri/3.0.0/docs/ch04.html#tools-xjc[Jakarta command line version] of XJC documentation.
+
 The following properties are available in the project-scoped `xjc` block, and apply to all XJC invocations
 (for all source sets):
 
@@ -71,6 +73,100 @@ The following property is available for each source set:
 | The target package for XJC.
 | `-p`
 | (not set)
+|===
+
+== JAXB Target Specification Version compatibility
+
+The version of JAXB and the version of XJC are not necessarily consistent.  The JAXB specification
+version follows the relevant JSR process while the XJC tool is updated in its maintenance lifecycle.
+
+The XJC -target option which is configured via `targetVersion` is the mechanism to use to override
+the default.  The following table is only known for the `com.sun.xml.bind` implementation of XJC.
+
+TIP: Some XJC tool versions may downgrade the default JAXB target (to 2.1) if they do not find a
+     2.2+ version of `javax.xml.bind:jaxb-api` on the XJC tool classpath.  For example if the `jaxb-api`
+     dependency is missing from the classpath because your configuration overrides plugin defaults.
+
+|===
+| XJC Tool Version | Default JAXB Spec Version | JAXB -target support | Package
+
+| 2.1 to 2.1.7
+| 2.1
+| 2.1, 2.0
+| javax
+
+| 2.1.8+
+| 2.2
+| 2.2, 2.1, 2.0
+| javax
+
+| 2.2
+| 2.2
+| 2.2, 2.1, 2.0
+| javax
+
+| 2.3
+| 2.2
+| 2.2, 2.1, 2.0
+| javax
+
+| 2.4
+| 2.2
+| 2.2, 2.1, 2.0
+| javax
+
+| 3.0
+| 3.0
+| 3.0, 2.3
+| jakarta
+
+| 4.0
+| 3.0
+| 3.0, 2.3
+| jakarta
+
+|===
+
+== JAXB Target Package compatibility
+
+This table maybe a useful reference.
+
+TIP: When expecting `jarkarta` package output, ensure to remove `javax.xml.bind:bind-api` from the XJC classpath.
+
+|===
+| XJC Tool Version | Default JAXB package | Supported package
+
+| 2.1 to 2.1.7
+| javax
+| javax
+
+| 2.1.8+
+| javax
+| javax
+
+| 2.2
+| javax
+| javax
+
+| 2.3
+| javax
+| javax
+
+| 2.4
+| javax
+| javax
+
+| 3.0
+| jakarta
+| jakarta (with -target 3.0) +
+  javax (with -target 2.3)
+
+
+| 4.0
+| jakarta
+| jakarta (with -target 3.0) +
+  javax (with -target 2.3)
+
 |===
 
 

--- a/docs/quickstart.adoc
+++ b/docs/quickstart.adoc
@@ -18,6 +18,24 @@ plugins {
 }
 ----
 
+It may be necessary to include a repository entry to allow Gradle to locate the plugin to active.
+
+[source,groovy,role="primary",subs="+attributes"]
+.Groovy
+----
+repositories {
+    gradlePluginPortal()
+}
+----
+
+[source,kotlin,role="secondary",subs="+attributes"]
+.Kotlin
+----
+repositories {
+    gradlePluginPortal()
+}
+----
+
 Put your XJC source files into `src/main/schema`. This includes XML schema files (extension `.xsd`),
 binding customizations (extension `.xjb`) and catalog files (extension `.cat`).
 

--- a/docs/using-episodes.adoc
+++ b/docs/using-episodes.adoc
@@ -36,13 +36,13 @@ generated from the `main` source set.
 
 Episode files are not consumed directly, but through JARs that contain them under `META-INF/sun-jaxb.episode`.
 To specify dependencies that contain episodes to be imported into the XJC build, add the libraries containing them
-to the `xjcEpisode` configuration:
+to the `xjcEpisodes` configuration:
 
 [source,groovy,role="primary"]
 .Groovy
 ----
 dependencies {
-    xjcEpisode 'org.example:my-model:1.2.3'
+    xjcEpisodes 'org.example:my-model:1.2.3'
 }
 ----
 
@@ -50,13 +50,13 @@ dependencies {
 .Kotlin
 ----
 dependencies {
-    "xjcEpisode"("org.example:my-model:1.2.3")
+    "xjcEpisodes"("org.example:my-model:1.2.3")
 }
 ----
 
 TIP: Each source set will get its own episode dependency configuration. For the `main` source set, this configuration
-is called `xjcEpisode`; for other source sets it will be called `<name>XjcEpisode`. For example, to specify episode
-dependencies for the `test` source set, use the `testXjcEpisode` configuration.
+is called `xjcEpisodes`; for other source sets it will be called `<name>XjcEpisodes`. For example, to specify episode
+dependencies for the `test` source set, use the `testXjcEpisodes` configuration.
 
 These dependencies should resolve to JAR files; if they contain a `META-INF/sun-jaxb.episode` entry it will be
 imported by the current `xjc` invocation. If they don't contain such a file they are simply ignored, so it is safe
@@ -68,7 +68,7 @@ For example, you might simply want to scan the entire `compileClasspath` for any
 .Groovy
 ----
 dependencies {
-    xjcEpisode configurations['compileClasspath']
+    xjcEpisodes configurations['compileClasspath']
 }
 ----
 
@@ -76,6 +76,6 @@ dependencies {
 .Kotlin
 ----
 dependencies {
-    "xjcEpisode"(configurations["compileClasspath"])
+    "xjcEpisodes"(configurations["compileClasspath"])
 }
 ----

--- a/docs/using-xjc-plugins.adoc
+++ b/docs/using-xjc-plugins.adoc
@@ -108,3 +108,85 @@ xjc {
 }
 ----
 ====
+
+
+== @Generated annotation support
+
+XJC can provide support for standard plugin activated with `-mark-generated` to emit additional Java annotations
+in the generated source.
+
+The implementation of XJC will impact exactly which package the @Generated is from, with the 2 options being `javax.annotation.Generated` and `jakarta.annotation.Generated`.  In order to allow
+Gradle JavaC to compile the output code and for the project to export the correct transative dependency
+you need to include the appropiate annotation-api dependency.
+
+The configuration for `javax.annotation.Generated` might look like this:
+
+[source,groovy,role="primary"]
+.Groovy
+----
+xjc {
+    // Ensure we are using a javax.annotation.Generated era version
+    xjcVersion = '2.3'  // maybe this configuration item could be omitted
+}
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitive dependency to the project
+    implementation 'javax.annotation:javax-annotation-api:1.3.2'
+}
+sourceSets {
+    main {
+        xjcExtraArgs.addAll '-mark-generated'
+    }
+}
+----
+
+[source,kotlin,role="secondary"]
+.Kotlin
+----
+xjc {
+    // Ensure we are using a javax.annotation.Generated era version
+    xjcVersion.set("2.3")  // maybe this configuration item could be omitted
+}
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitive dependency to the project
+    implementation("javax.annotation:javax-annotation-api:1.3.2")
+}
+sourceSets.named("main") {
+    xjcExtraArgs.addAll("-mark-generated")
+}
+----
+
+The configuration for `jakarta.annotation.Generated` might look like this:
+
+[source,groovy,role="primary"]
+.Groovy
+----
+xjc {
+    // Ensure we are using a javax.annotation.Generated era version
+    xjcVersion = '3.0'  // maybe this configuration item could be omitted
+}
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitive dependency to the project
+    implementation 'jakarta.annotation:javax-annotation-api:1.3.5'
+}
+sourceSets {
+    main {
+        xjcExtraArgs.addAll '-mark-generated'
+    }
+}
+----
+
+[source,kotlin,role="secondary"]
+.Kotlin
+----
+xjc {
+    // Ensure we are using a javax.annotation.Generated era version
+    xjcVersion.set("3.0")  // maybe this configuration item could be omitted
+}
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitive dependency to the project
+    implementation("jakarta.annotation:javax-annotation-api:1.3.5")
+}
+sourceSets.named("main") {
+    xjcExtraArgs.addAll("-mark-generated")
+}
+----

--- a/docs/working-with-catalogs.adoc
+++ b/docs/working-with-catalogs.adoc
@@ -72,7 +72,7 @@ useful for multi-step code generation where a library JAR contains the schema, a
 ----
 dependencies {
     implementation 'com.example:my-model:1.2.3'
-    xjcEpisode configurations['compileClasspath']
+    xjcEpisodes configurations['compileClasspath']
 }
 ----
 
@@ -81,7 +81,7 @@ dependencies {
 ----
 dependencies {
     implementation("com.example:my-model:1.2.3")
-    "xjcEpisode"(configurations["compileClasspath"])
+    "xjcEpisodes"(configurations["compileClasspath"])
 }
 ----
 

--- a/docs/working-with-catalogs.adoc
+++ b/docs/working-with-catalogs.adoc
@@ -141,3 +141,13 @@ declared in the `xjcCatalogResolution` configuration (or inherited through other
 
 You can think of the `maven:` scheme as an extension to `classpath:` with a filter for the JARs to be searched
 for resources. (In fact, `classpath:` is defined as an alias for `maven::!`.)
+
+
+=== Catalog resolution diagnostic
+
+.Suggestions:
+ * --info (dump XJC configuration)
+ * --debug (see catalog resolution working)
+ * -Dxml.catalog.verbosity=999 for info at
+   https://xerces.apache.org/xml-commons/components/apidocs/resolver/org/apache/xml/resolver/CatalogManager.html
+ * Lookup documentation around Apache Xerces CatalogManager.properties

--- a/docs/xjc-versions.adoc
+++ b/docs/xjc-versions.adoc
@@ -56,7 +56,11 @@ invoking XJC, with the following dependencies:
 | `com.sun.xml.bind:jaxb-xjc:2.3.3`
 
 | 3.0
-| `com.sun.xml.bind:jaxb-xjc:3.0.0-M4`
+| `com.sun.xml.bind:jaxb-xjc:3.0.2`
+  `com.sun.xml.bind:jaxb-core:3.0.2`
+  `com.sun.xml.bind:jaxb-impl:3.0.2`
+  `jakarta.xml.bind:jakarta.xml.bind-api:3.0.1`
+
 |===
 
 
@@ -66,13 +70,20 @@ You can also manually configure the classpath for invoking XJC by adding depende
 to the `xjcTool` configuration. As soon as this configuration contains any dependencies,
 the defaults will back away, and the `xjc.xjcVersion` property will have no effect.
 
+You should specify at least `jaxb-xjc` it is possible its dependencies are included
+transitively or you can include them with additional `xjcTool` directives.
+
 For example:
 
 [source,groovy,role="primary"]
 .Groovy
 ----
 dependencies {
-    xjcTool 'com.sun.xml.bind:jaxb-xjc:3.0.0-M4'
+    xjcTool 'com.sun.xml.bind:jaxb-xjc:3.0.2'
+    // Optional explicit version set:
+    xjcTool 'com.sun.xml.bind:jaxb-core:3.0.2'
+    xjcTool 'com.sun.xml.bind:jaxb-impl:3.0.2'
+    xjcTool 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
 }
 ----
 
@@ -80,6 +91,10 @@ dependencies {
 .Kotlin
 ----
 dependencies {
-    "xjcTool"("com.sun.xml.bind:jaxb-xjc:3.0.0-M4")
+    "xjcTool"("com.sun.xml.bind:jaxb-xjc:3.0.2")
+    // Optional explicit version set:
+    "xjcTool"("com.sun.xml.bind:jaxb-core:3.0.2")
+    "xjcTool"("com.sun.xml.bind:jaxb-impl:3.0.2")
+    "xjcTool"("jakarta.xml.bind:jakarta.xml.bind-api:3.0.1")
 }
 ----

--- a/docs/xjc-versions.adoc
+++ b/docs/xjc-versions.adoc
@@ -53,7 +53,10 @@ invoking XJC, with the following dependencies:
   `javax.xml.bind:jaxb-api:2.2.11`
 
 | 2.3
-| `com.sun.xml.bind:jaxb-xjc:2.3.3`
+| `com.sun.xml.bind:jaxb-xjc:2.3.8`
+  `com.sun.xml.bind:jaxb-core:2.3.0.1`
+  `com.sun.xml.bind:jaxb-impl:2.3.8`
+  `javax.xml.bind:jaxb-api:2.3.1`
 
 | 2.4
 | `com.sun.xml.bind:jaxb-xjc:2.4.0-b180830.0438`

--- a/docs/xjc-versions.adoc
+++ b/docs/xjc-versions.adoc
@@ -4,7 +4,7 @@ XJC has been around for a long time and comes in a variety of versions, includin
 Oracle and non-standard forks from third parties. They should usually correspond with the version of the JAXB
 API / runtime used, but it is also possible to use a newer XJC to generate code for use with an earlier JAXB target.
 
-The `org.unbroken-dome.xjc` plugin supports the standard XJC versions 2.2, 2.3 and 3.0. Other versions may work
+The `org.unbroken-dome.xjc` plugin supports the standard XJC versions 2.2, 2.3, 2.4 and 3.0. Other versions may work
 as well but are not tested. The plugin will use XJC 2.3 by default if the version is not specified.
 
 NOTE: XJC 3.0 is currently in milestone status but since the interface to XJC has not
@@ -54,6 +54,12 @@ invoking XJC, with the following dependencies:
 
 | 2.3
 | `com.sun.xml.bind:jaxb-xjc:2.3.3`
+
+| 2.4
+| `com.sun.xml.bind:jaxb-xjc:2.4.0-b180830.0438`
+  `com.sun.xml.bind:jaxb-core:2.3.0.1`
+  `com.sun.xml.bind:jaxb-impl:2.4.0-b180830.0438`
+  `javax.xml.bind:jaxb-api:2.4.0-b180830.0359`
 
 | 3.0
 | `com.sun.xml.bind:jaxb-xjc:3.0.2`

--- a/docs/xjc-versions.adoc
+++ b/docs/xjc-versions.adoc
@@ -50,7 +50,7 @@ invoking XJC, with the following dependencies:
 | `com.sun.xml.bind:jaxb-xjc:2.2.11`
   `com.sun.xml.bind:jaxb-core:2.2.11`
   `com.sun.xml.bind:jaxb-impl:2.2.11`
-  `javax.xml.bind:jaxb-api:2.2.11`
+  `javax.xml.bind:jaxb-api:2.2.12`
 
 | 2.3
 | `com.sun.xml.bind:jaxb-xjc:2.3.8`

--- a/docs/xjc-versions.adoc
+++ b/docs/xjc-versions.adoc
@@ -4,7 +4,7 @@ XJC has been around for a long time and comes in a variety of versions, includin
 Oracle and non-standard forks from third parties. They should usually correspond with the version of the JAXB
 API / runtime used, but it is also possible to use a newer XJC to generate code for use with an earlier JAXB target.
 
-The `org.unbroken-dome.xjc` plugin supports the standard XJC versions 2.2, 2.3, 2.4 and 3.0. Other versions may work
+The `org.unbroken-dome.xjc` plugin supports the standard XJC versions 2.2, 2.3, 2.4, 3.0 and 4.0. Other versions may work
 as well but are not tested. The plugin will use XJC 2.3 by default if the version is not specified.
 
 NOTE: XJC 3.0 is currently in milestone status but since the interface to XJC has not
@@ -69,6 +69,12 @@ invoking XJC, with the following dependencies:
   `com.sun.xml.bind:jaxb-core:3.0.2`
   `com.sun.xml.bind:jaxb-impl:3.0.2`
   `jakarta.xml.bind:jakarta.xml.bind-api:3.0.1`
+
+| 4.0
+| `com.sun.xml.bind:jaxb-xjc:4.0.2`
+  `com.sun.xml.bind:jaxb-core:4.0.2`
+  `com.sun.xml.bind:jaxb-impl:4.0.2`
+  `jakarta.xml.bind:jakarta.xml.bind-api:4.0.0`
 
 |===
 

--- a/docs/xjc-versions.adoc
+++ b/docs/xjc-versions.adoc
@@ -4,7 +4,7 @@ XJC has been around for a long time and comes in a variety of versions, includin
 Oracle and non-standard forks from third parties. They should usually correspond with the version of the JAXB
 API / runtime used, but it is also possible to use a newer XJC to generate code for use with an earlier JAXB target.
 
-The `org.unbroken-dome.xjc` plugin supports the standard XJC versions 2.2, 2.3, 2.4, 3.0 and 4.0. Other versions may work
+The `org.unbroken-dome.xjc` plugin supports the standard XJC versions 2.1, 2.2, 2.3, 2.4, 3.0 and 4.0. Other versions may work
 as well but are not tested. The plugin will use XJC 2.3 by default if the version is not specified.
 
 NOTE: XJC 3.0 is currently in milestone status but since the interface to XJC has not
@@ -45,6 +45,13 @@ invoking XJC, with the following dependencies:
 [cols="1,4"]
 |===
 | XJC Version | Classpath artifacts
+
+| 2.1
+| `com.sun.xml.bind:jaxb-xjc:2.1.17`
+  `com.sun.xml.bind:jaxb-core:2.1.14`
+  `com.sun.xml.bind:jaxb-impl:2.1.17`
+  `javax.xml.bind:jaxb-api:2.1`
+
 
 | 2.2
 | `com.sun.xml.bind:jaxb-xjc:2.2.11`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,26 @@
+# For CI purposes these are now property overrides to help matrix test environment scenarios
+# With JVM and Gradle versions for building this project (not consuming the output plugin of this project)
+
+# Gradle 6.5, Kotlin 1.3.72(1.3)
+# Gradle 7.3, Kotlin 1.5.31(1.4) JDK17
+# Gradle 7.5, Kotlin 1.6.21(1.4) configuration-cache
+# Gradle 8.5, Kotlin 1.9.20(1.8) JDK21
+
+## Gradle 8.x building and testing
+#kotlinVersion=1.9.20
+# This needs Java11+ but is the first version to support Gradle 8.x
+#testSetsVersion=4.1.0
+
+## Gradle 7.x building and testing
+#kotlinVersion=1.6.21
+#testSetsVersion=4.0.0
+
+## Gradle 5.x 6.x building and testing
 kotlinVersion=1.3.72
+testSetsVersion=3.0.1
+
+#
+#
 
 group=org.unbroken-dome.gradle-plugins
 version=2.1.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ testSetsVersion=3.0.1
 #
 
 group=org.unbroken-dome.gradle-plugins
-version=2.1.0-SNAPSHOT
+version=2.2.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,10 @@
 
 ## Gradle 8.x building and testing
 #kotlinVersion=1.9.20
-# This needs Java11+ but is the first version to support Gradle 8.x
+## The official org.unbroken-dome.test-sets 4.1.0 Needs Java11+ and is the first version to support Gradle 8.x
+##testSetsVersion=4.0.0
+## So this is why these comments exist, but we now use unofficial:
+##org.darrylmiles.repack.org.unbroken-dome.test-sets which a release in Java8 bytecode of 4.1.0
 #testSetsVersion=4.1.0
 
 ## Gradle 7.x building and testing

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlinVersion=1.3.72
 
 group=org.unbroken-dome.gradle-plugins
-version=2.0.0
+version=2.1.0-SNAPSHOT

--- a/publish.gradle.kts
+++ b/publish.gradle.kts
@@ -1,0 +1,27 @@
+import org.gradle.api.publish.PublishingExtension
+
+allprojects {
+    apply(plugin = "maven-publish")
+
+    tasks.withType<Javadoc>().configureEach {
+        options {
+            this as StandardJavadocDocletOptions
+
+            if(JavaVersion.current().isJava8Compatible()) {
+                addStringOption("Xdoclint:none", "-quiet")
+            }
+            if(JavaVersion.current().isJava9Compatible()) {
+                addBooleanOption("html5", true)
+            }
+        }
+    }
+
+    configure<PublishingExtension> {
+        repositories {
+            maven {
+                // Default is Maven buildDirectory publish only
+                url = uri(layout.buildDirectory.dir("repo"))
+            }
+        }
+    }
+}

--- a/publish.gradle.kts
+++ b/publish.gradle.kts
@@ -22,6 +22,28 @@ allprojects {
                 // Default is Maven buildDirectory publish only
                 url = uri(layout.buildDirectory.dir("repo"))
             }
+
+
+
+            if(findProperty("doGitHubPackagesPublish") == "true") {
+                val GITHUB_ACTOR = System.getenv("GITHUB_USERNAME") ?: System.getenv("GITHUB_ACTOR") ?: throw IllegalArgumentException()
+                val GITHUB_TOKEN = System.getenv("GITHUB_TOKEN") ?: System.getenv("GH_TOKEN") ?: throw IllegalArgumentException()
+                val GITHUB_REPOSITORY = System.getenv("GITHUB_REPOSITORY")
+
+                assert(GITHUB_ACTOR.isNotEmpty() == true)
+                assert(GITHUB_TOKEN.isNotEmpty() == true)
+                assert(GITHUB_REPOSITORY.isNotEmpty() == true)
+
+                maven {
+                    name = "GitHubPackages"
+                    url = uri("https://maven.pkg.github.com/${GITHUB_REPOSITORY}")
+                    credentials {
+                        username = GITHUB_ACTOR
+                        password = GITHUB_TOKEN
+                    }
+                }
+            }
         }
     }
 }
+

--- a/samples/groovy-dsl/basic/build.gradle
+++ b/samples/groovy-dsl/basic/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/groovy-dsl/basic/build.gradle
+++ b/samples/groovy-dsl/basic/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/basic/build.gradle
+++ b/samples/groovy-dsl/basic/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/bindings/build.gradle
+++ b/samples/groovy-dsl/bindings/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '2.3'
+}
+
+
+dependencies {
+    implementation 'javax.xml.bind:jaxb-api:2.3.0'
+}

--- a/samples/groovy-dsl/bindings/build.gradle
+++ b/samples/groovy-dsl/bindings/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/bindings/settings.gradle
+++ b/samples/groovy-dsl/bindings/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'bindings'

--- a/samples/groovy-dsl/bindings/src/main/schema/books.xjb
+++ b/samples/groovy-dsl/bindings/src/main/schema/books.xjb
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings
+        xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+        xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+        jaxb:version="2.0">
+
+    <jaxb:bindings schemaLocation="books.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="org.unbroken_dome.gradle_xjc_plugin.samples.books.alt.package_name"/>
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+
+</jaxb:bindings>

--- a/samples/groovy-dsl/bindings/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/bindings/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/bindings_jakarta/build.gradle
+++ b/samples/groovy-dsl/bindings_jakarta/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '3.0'
+}
+
+
+dependencies {
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
+}

--- a/samples/groovy-dsl/bindings_jakarta/build.gradle
+++ b/samples/groovy-dsl/bindings_jakarta/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/bindings_jakarta/settings.gradle
+++ b/samples/groovy-dsl/bindings_jakarta/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'bindings_jakarta'

--- a/samples/groovy-dsl/bindings_jakarta/src/main/schema/books.xjb
+++ b/samples/groovy-dsl/bindings_jakarta/src/main/schema/books.xjb
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings
+        xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+        xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jaxb https://jakarta.ee/xml/ns/jaxb/bindingschema_3_0.xsd"
+        jaxb:version="3.0">
+
+    <jaxb:bindings schemaLocation="books.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="org.unbroken_dome.gradle_xjc_plugin.samples.books.alt.package_name"/>
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+
+</jaxb:bindings>

--- a/samples/groovy-dsl/bindings_jakarta/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/bindings_jakarta/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/catalogs/build.gradle
+++ b/samples/groovy-dsl/catalogs/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/samples/groovy-dsl/catalogs/consumer/build.gradle
+++ b/samples/groovy-dsl/catalogs/consumer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/catalogs/consumer/build.gradle
+++ b/samples/groovy-dsl/catalogs/consumer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/complete/build.gradle
+++ b/samples/groovy-dsl/complete/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/samples/groovy-dsl/complete/consumer/build.gradle
+++ b/samples/groovy-dsl/complete/consumer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/complete/consumer/build.gradle
+++ b/samples/groovy-dsl/complete/consumer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/complete/library/build.gradle
+++ b/samples/groovy-dsl/complete/library/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java-library')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/complete/library/build.gradle
+++ b/samples/groovy-dsl/complete/library/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java-library')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/doclocale/build.gradle
+++ b/samples/groovy-dsl/doclocale/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 repositories {

--- a/samples/groovy-dsl/doclocale/build.gradle
+++ b/samples/groovy-dsl/doclocale/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+repositories {
+    mavenCentral()
+}
+
+xjc {
+    docLocale = "it"
+}
+
+
+dependencies {
+    implementation 'javax.xml.bind:jaxb-api:2.3.0'
+}

--- a/samples/groovy-dsl/doclocale/settings.gradle
+++ b/samples/groovy-dsl/doclocale/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'doclocale'

--- a/samples/groovy-dsl/doclocale/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/doclocale/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/episodes/build.gradle
+++ b/samples/groovy-dsl/episodes/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/samples/groovy-dsl/episodes/episode-consumer/build.gradle
+++ b/samples/groovy-dsl/episodes/episode-consumer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/episodes/episode-consumer/build.gradle
+++ b/samples/groovy-dsl/episodes/episode-consumer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/episodes/episode-producer/build.gradle
+++ b/samples/groovy-dsl/episodes/episode-producer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java-library')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/episodes/episode-producer/build.gradle
+++ b/samples/groovy-dsl/episodes/episode-producer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java-library')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/remote-schema/build.gradle
+++ b/samples/groovy-dsl/remote-schema/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/groovy-dsl/remote-schema/build.gradle
+++ b/samples/groovy-dsl/remote-schema/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/remote-schema/build.gradle
+++ b/samples/groovy-dsl/remote-schema/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/wsdl/build.gradle
+++ b/samples/groovy-dsl/wsdl/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+xjc {
+    // This maybe inferred from the filename extension provided to XJC
+    extraArgs.addAll "-wsdl"
+}
+
+// With wsimport there is:
+//  cd src/main/schema
+//  mkdir out
+//  wsimport -verbose -keep -extension -b books.xjb -d out -wsdllocation "http://localhost/book/lookup/service" -Xdebug -XdisableAuthenticator books.wsdl
+// But this is outside the scope of XJB see other gradle plugins for wsimport support
+
+// XJC seems able to produce JAXB for *.wsdl and *.xsd but it includes all eligible
+//   file extensions from src/main/schema/** so when imports are used it appears to
+//   need those file to be relocated outside of src/main/schema so this is the reason
+//   for the schema_other directory
+
+dependencies {
+    implementation 'javax.xml.bind:jaxb-api:2.3.0'
+}

--- a/samples/groovy-dsl/wsdl/settings.gradle
+++ b/samples/groovy-dsl/wsdl/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'wsdl'

--- a/samples/groovy-dsl/wsdl/src/main/schema/books.wsdl
+++ b/samples/groovy-dsl/wsdl/src/main/schema/books.wsdl
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<wsdl:definitions
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup/service"
+        xmlns:look="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup"
+        xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+        xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+        name="BookLookupEndpointService"
+        targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup/service">
+
+
+    <wsdl:types>
+        <!-- the schema elements should be enumerated by XJC -->
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                   xmlns:look="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup"
+                   attributeFormDefault="unqualified"
+                   elementFormDefault="qualified"
+                   targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup/service"
+                   version="1.0">
+            <xsd:import namespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup" schemaLocation="lookup.xsd"/>
+        </xs:schema>
+    </wsdl:types>
+
+    <wsdl:message name="searchRequest">
+        <wsdl:part name="request" element="look:searchRequest"/>
+    </wsdl:message>
+
+    <wsdl:message name="searchResponse">
+        <wsdl:part name="result" element="look:searchResult"/>
+    </wsdl:message>
+
+    <wsdl:portType name="Search_PortType">
+        <wsdl:operation name="searchRequest">
+            <wsdl:input message="tns:searchRequest"/>
+            <wsdl:output message="tns:searchResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="Search_Binding" type="tns:Search_PortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="searchRequest">
+            <soap:operation soapAction="urn:searchAction"/>
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+                           use="literal"
+                           />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+                           use="literal"
+                           />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="Search_Service">
+        <wsdl:documentation>WSDL File Sample for Search_Service</wsdl:documentation>
+        <wsdl:port name="Search_Port" binding="tns:Search_Binding">
+            <soap:address location="http://localhost/gradle-xjc-plugin/samples/wsdl-basic/Search_Service/"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>

--- a/samples/groovy-dsl/wsdl/src/main/schema/books.xjb
+++ b/samples/groovy-dsl/wsdl/src/main/schema/books.xjb
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings
+        xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+        xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+        jaxb:version="2.0">
+
+    <jaxb:bindings schemaLocation="../schema_other/common.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="org.unbroken_dome.gradle_xjc_plugin.samples.books.alt.common"/>
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+
+    <jaxb:bindings schemaLocation="lookup.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="org.unbroken_dome.gradle_xjc_plugin.samples.books.alt.lookup"/>
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+
+</jaxb:bindings>

--- a/samples/groovy-dsl/wsdl/src/main/schema/lookup.xsd
+++ b/samples/groovy-dsl/wsdl/src/main/schema/lookup.xsd
@@ -1,0 +1,48 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:com="http://unbroken-dome.org/gradle-xjc-plugin/samples/common"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup">
+
+    <xsd:import namespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/common" schemaLocation="../schema_other/common.xsd"/>
+    <xsd:import namespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books" schemaLocation="../schema_other/books.xsd"/>
+
+    <!--
+        <searchRequest>
+            <term>first term</term>
+            <term>second term</term>
+        </searchRequest>
+    -->
+    <xsd:element name="searchRequest">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element maxOccurs="unbounded" name="term" type="xsd:string"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+    <!--
+        <searchResult>
+            <searchResultItem>
+                <index>1</index>
+                <details>result info</details>
+                <bookId><bookIsbn>1234567890X</bookIsbn></bookId>
+            </searchResultItem>
+        </searchResult>
+    -->
+    <xsd:complexType name="searchResultItem">
+        <xsd:sequence>
+            <xsd:element name="index" type="xsd:positiveInteger"/>
+            <xsd:element name="details" type="xsd:string"/>
+            <xsd:element name="bookId" type="com:bookId" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="searchResult">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element minOccurs="0" maxOccurs="unbounded" name="result" type="tns:searchResultItem"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+</xsd:schema>

--- a/samples/groovy-dsl/wsdl/src/main/schema_other/books.xsd
+++ b/samples/groovy-dsl/wsdl/src/main/schema_other/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/wsdl/src/main/schema_other/common.xsd
+++ b/samples/groovy-dsl/wsdl/src/main/schema_other/common.xsd
@@ -1,0 +1,11 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/common"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/common">
+
+    <xsd:complexType name="bookId">
+        <xsd:attribute name="isbn" type="xsd:string"/>
+    </xsd:complexType>
+
+    <xsd:element name="bookIsbn" type="tns:bookId"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-plugin/build.gradle
+++ b/samples/groovy-dsl/xjc-plugin/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/groovy-dsl/xjc-plugin/build.gradle
+++ b/samples/groovy-dsl/xjc-plugin/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-plugin/build.gradle
+++ b/samples/groovy-dsl/xjc-plugin/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-tool-2_1-legacy/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_1-legacy/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-tool-2_1-legacy/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_1-legacy/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '2.1'
+}
+
+
+dependencies {
+    // These legacy jars do not have any OSGi MANIFEST data,
+    //   that is what makes them legacy as plugin auto-detect works slightly different
+    implementation 'javax.xml.bind:jaxb-api:2.1'
+
+    xjcTool 'javax.xml.bind:jaxb-api:2.1'
+
+    xjcTool 'com.sun.xml.bind:jaxb-xjc:2.1.17'
+    xjcTool 'com.sun.xml.bind:jaxb-impl:2.1.17'
+    xjcTool 'com.sun.xml.bind:jaxb-core:2.1.14'
+}

--- a/samples/groovy-dsl/xjc-tool-2_1-legacy/settings.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_1-legacy/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-tool-2_1-legacy'

--- a/samples/groovy-dsl/xjc-tool-2_1-legacy/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-tool-2_1-legacy/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-tool-2_2-legacy/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_2-legacy/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '2.2'
+}
+
+
+dependencies {
+    // These legacy jars do not have any OSGi MANIFEST data,
+    //   that is what makes them legacy as plugin auto-detect works slightly different
+    implementation 'javax.xml.bind:jaxb-api:2.2.7'
+
+    xjcTool 'javax.xml.bind:jaxb-api:2.2.7'
+
+    xjcTool 'com.sun.xml.bind:jaxb-xjc:2.2.7'
+    xjcTool 'com.sun.xml.bind:jaxb-impl:2.2.7'
+    xjcTool 'com.sun.xml.bind:jaxb-core:2.2.7'
+}

--- a/samples/groovy-dsl/xjc-tool-2_2-legacy/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_2-legacy/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-tool-2_2-legacy/settings.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_2-legacy/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-tool-2_2-legacy'

--- a/samples/groovy-dsl/xjc-tool-2_2-legacy/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-tool-2_2-legacy/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-tool-2_2/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_2/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-tool-2_2/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_2/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '2.2'
+}
+
+
+dependencies {
+    implementation 'javax.xml.bind:jaxb-api:2.2.12'
+
+    xjcTool 'javax.xml.bind:jaxb-api:2.2.12'
+
+    xjcTool 'com.sun.xml.bind:jaxb-xjc:2.2.11'
+    xjcTool 'com.sun.xml.bind:jaxb-impl:2.2.11'
+    xjcTool 'com.sun.xml.bind:jaxb-core:2.2.11'
+}

--- a/samples/groovy-dsl/xjc-tool-2_2/settings.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_2/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-tool-2_2'

--- a/samples/groovy-dsl/xjc-tool-2_2/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-tool-2_2/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-tool-2_3/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_3/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '2.3'
+}
+
+
+dependencies {
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+
+    xjcTool 'com.sun.xml.bind:jaxb-xjc:2.3.8'
+}

--- a/samples/groovy-dsl/xjc-tool-2_3/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_3/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-tool-2_3/settings.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_3/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-tool-2_3'

--- a/samples/groovy-dsl/xjc-tool-2_3/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-tool-2_3/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-tool-2_4/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_4/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '2.4'
+}
+
+
+dependencies {
+    implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+
+    xjcTool 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+
+    xjcTool 'com.sun.xml.bind:jaxb-xjc:2.4.0-b180830.0438'
+    xjcTool 'com.sun.xml.bind:jaxb-impl:2.4.0-b180830.0438'
+    xjcTool 'com.sun.xml.bind:jaxb-core:2.3.0.1'  // there is no 2.4 version
+}

--- a/samples/groovy-dsl/xjc-tool-2_4/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_4/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-tool-2_4/settings.gradle
+++ b/samples/groovy-dsl/xjc-tool-2_4/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-tool-2_4'

--- a/samples/groovy-dsl/xjc-tool-2_4/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-tool-2_4/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-tool-3_0-target-2_3/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-3_0-target-2_3/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-tool-3_0-target-2_3/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-3_0-target-2_3/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '3.0'
+    targetVersion = '2.3'
+}
+
+
+dependencies {
+    // Yes this looks wrong, based on XJC command line usage:
+    //    XJC 3.x/4.x itself does not need javax.xml.bind on its classpath,
+    //       it needs jakarta.xml.bind for generation.
+    //    JavaC does need to see javax.xml.bind as that is what is in the generated *.java
+
+    implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+
+    xjcTool 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
+
+    xjcTool 'com.sun.xml.bind:jaxb-xjc:3.0.2'
+}

--- a/samples/groovy-dsl/xjc-tool-3_0-target-2_3/settings.gradle
+++ b/samples/groovy-dsl/xjc-tool-3_0-target-2_3/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-tool-3_0-target-2_3'

--- a/samples/groovy-dsl/xjc-tool-3_0-target-2_3/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-tool-3_0-target-2_3/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-tool-3_0/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-3_0/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '3.0'
+}
+
+
+dependencies {
+    // XJC 3.0 requires a different JAXB API artifact
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
+
+    xjcTool 'com.sun.xml.bind:jaxb-xjc:3.0.2'
+}

--- a/samples/groovy-dsl/xjc-tool-3_0/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-3_0/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-tool-3_0/settings.gradle
+++ b/samples/groovy-dsl/xjc-tool-3_0/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-tool-3_0'

--- a/samples/groovy-dsl/xjc-tool-3_0/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-tool-3_0/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-tool-4_0/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-4_0/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '4.0'
+}
+
+
+dependencies {
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
+
+    xjcTool 'com.sun.xml.bind:jaxb-xjc:4.0.2'
+}

--- a/samples/groovy-dsl/xjc-tool-4_0/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-4_0/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-tool-4_0/settings.gradle
+++ b/samples/groovy-dsl/xjc-tool-4_0/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-tool-4_0'

--- a/samples/groovy-dsl/xjc-tool-4_0/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-tool-4_0/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-tool-future-latest/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-future-latest/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-tool-future-latest/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-future-latest/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '99.0'
+    xjcVersionUnsupportedStrategy = 'latest'
+}
+
+
+dependencies {
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
+
+    xjcTool 'com.sun.xml.bind:jaxb-xjc:4.0.2'
+}

--- a/samples/groovy-dsl/xjc-tool-future-latest/settings.gradle
+++ b/samples/groovy-dsl/xjc-tool-future-latest/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-tool-future-latest'

--- a/samples/groovy-dsl/xjc-tool-future-latest/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-tool-future-latest/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-tool-future/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-future/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-tool-future/build.gradle
+++ b/samples/groovy-dsl/xjc-tool-future/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '99.0'
+    //// This is testing build failure and error output due to not configuring:
+    //xjcVersionUnsupportedStrategy = 'auto-resolve'
+}
+
+
+dependencies {
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
+
+    // For this integration test to be JDK8 compatible this needs to be 3.x or older
+    // But doing that means that tests would never demonstrate itself working at the
+    // time the feature was added, as 3.x was supported already, so we only perform
+    // this test in JDK11+ while we don't yet support 4.x.
+    xjcTool 'com.sun.xml.bind:jaxb-xjc:4.0.2'
+}

--- a/samples/groovy-dsl/xjc-tool-future/settings.gradle
+++ b/samples/groovy-dsl/xjc-tool-future/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-tool-future'

--- a/samples/groovy-dsl/xjc-tool-future/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-tool-future/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-version-2_1-legacy/build.gradle
+++ b/samples/groovy-dsl/xjc-version-2_1-legacy/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '2.1'
+}
+
+
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitively
+    implementation 'javax.xml.bind:jaxb-api:2.1'
+}

--- a/samples/groovy-dsl/xjc-version-2_1-legacy/build.gradle
+++ b/samples/groovy-dsl/xjc-version-2_1-legacy/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-2_1-legacy/settings.gradle
+++ b/samples/groovy-dsl/xjc-version-2_1-legacy/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-version-2_1-legacy'

--- a/samples/groovy-dsl/xjc-version-2_1-legacy/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-version-2_1-legacy/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-version-2_2/build.gradle
+++ b/samples/groovy-dsl/xjc-version-2_2/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/groovy-dsl/xjc-version-2_2/build.gradle
+++ b/samples/groovy-dsl/xjc-version-2_2/build.gradle
@@ -15,5 +15,6 @@ xjc {
 
 
 dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitively
     implementation 'javax.xml.bind:jaxb-api:2.2.12'
 }

--- a/samples/groovy-dsl/xjc-version-2_2/build.gradle
+++ b/samples/groovy-dsl/xjc-version-2_2/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-2_2/build.gradle
+++ b/samples/groovy-dsl/xjc-version-2_2/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-2_3/build.gradle
+++ b/samples/groovy-dsl/xjc-version-2_3/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '2.3'
+}
+
+
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitively
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+}

--- a/samples/groovy-dsl/xjc-version-2_3/build.gradle
+++ b/samples/groovy-dsl/xjc-version-2_3/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-2_3/settings.gradle
+++ b/samples/groovy-dsl/xjc-version-2_3/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-version-2_3'

--- a/samples/groovy-dsl/xjc-version-2_3/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-version-2_3/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-version-2_4/build.gradle
+++ b/samples/groovy-dsl/xjc-version-2_4/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '2.4'
+}
+
+
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitively
+    implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+}

--- a/samples/groovy-dsl/xjc-version-2_4/build.gradle
+++ b/samples/groovy-dsl/xjc-version-2_4/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-2_4/settings.gradle
+++ b/samples/groovy-dsl/xjc-version-2_4/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-version-2_4'

--- a/samples/groovy-dsl/xjc-version-2_4/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-version-2_4/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-version-3_0-target-2_3/build.gradle
+++ b/samples/groovy-dsl/xjc-version-3_0-target-2_3/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-3_0-target-2_3/build.gradle
+++ b/samples/groovy-dsl/xjc-version-3_0-target-2_3/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '3.0'
+    targetVersion = '2.3'
+}
+
+
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitively
+    implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+}

--- a/samples/groovy-dsl/xjc-version-3_0-target-2_3/settings.gradle
+++ b/samples/groovy-dsl/xjc-version-3_0-target-2_3/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-version-3_0-target-2_3'

--- a/samples/groovy-dsl/xjc-version-3_0-target-2_3/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-version-3_0-target-2_3/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-version-3_0/build.gradle
+++ b/samples/groovy-dsl/xjc-version-3_0/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/groovy-dsl/xjc-version-3_0/build.gradle
+++ b/samples/groovy-dsl/xjc-version-3_0/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.0.0'
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-3_0/build.gradle
+++ b/samples/groovy-dsl/xjc-version-3_0/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-3_0/build.gradle
+++ b/samples/groovy-dsl/xjc-version-3_0/build.gradle
@@ -15,6 +15,6 @@ xjc {
 
 
 dependencies {
-    // XJC 3.0 requires a different JAXB API artifact
-    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.0-RC3'
+    // This is still needed for Gradle to compile the generated Java and add transitively
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
 }

--- a/samples/groovy-dsl/xjc-version-4_0/build.gradle
+++ b/samples/groovy-dsl/xjc-version-4_0/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-4_0/build.gradle
+++ b/samples/groovy-dsl/xjc-version-4_0/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion = '4.0'
+}
+
+
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitively
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
+}

--- a/samples/groovy-dsl/xjc-version-4_0/settings.gradle
+++ b/samples/groovy-dsl/xjc-version-4_0/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-version-4_0'

--- a/samples/groovy-dsl/xjc-version-4_0/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-version-4_0/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-version-default/build.gradle
+++ b/samples/groovy-dsl/xjc-version-default/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-default/build.gradle
+++ b/samples/groovy-dsl/xjc-version-default/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+dependencies {
+    // 2.3 is the default xjcVersion
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+}

--- a/samples/groovy-dsl/xjc-version-default/settings.gradle
+++ b/samples/groovy-dsl/xjc-version-default/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-version-default'

--- a/samples/groovy-dsl/xjc-version-default/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-version-default/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-version-ext-basics-annox/build.gradle
+++ b/samples/groovy-dsl/xjc-version-ext-basics-annox/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-ext-basics-annox/build.gradle
+++ b/samples/groovy-dsl/xjc-version-ext-basics-annox/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+xjc {
+    extraArgs.addAll '-Xannotate'
+    extension = true
+}
+
+dependencies {
+    // 2.3 is the default xjcVersion
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+
+    // Picked 2.0.9 for middling Java8/XJC2.3 support but if you research and fixup your
+    // environment and dependencies here you could go newer or older with Java/XJC.
+    // -Xannotate: means you need to add dependency:
+    xjcClasspath 'org.jvnet.jaxb:jaxb2-basics:2.0.9'
+    //xjcClasspath 'org.jvnet.jaxb:jaxb-annox:2.0.9'
+    xjcClasspath 'org.jvnet.jaxb:jaxb-basics-annotate:2.0.9'
+
+    // Don't forget to include your implementation dependencies for the annotations themselves
+    // A random arbitrary annotation library to demonstrate use, replace with the ones you described in XJB
+    implementation 'javax.validation:validation-api:2.0.1.Final'
+
+}

--- a/samples/groovy-dsl/xjc-version-ext-basics-annox/settings.gradle
+++ b/samples/groovy-dsl/xjc-version-ext-basics-annox/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-version-ext-basics-annox'

--- a/samples/groovy-dsl/xjc-version-ext-basics-annox/src/main/schema/books.xjb
+++ b/samples/groovy-dsl/xjc-version-ext-basics-annox/src/main/schema/books.xjb
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings
+        xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+        xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:annox="http://annox.dev.java.net"
+        xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+        jaxb:version="2.1">
+
+    <jaxb:bindings schemaLocation="books.xsd" node="/xs:schema">
+        <jaxb:bindings node="//xs:complexType[@name='bookType']">
+            <annox:annotateClass>@javax.xml.bind.annotation.XmlRootElement(name="BookTypeHasBeenRenamed")</annox:annotateClass>
+        </jaxb:bindings>
+        <jaxb:bindings node="//xs:complexType[@name='bookType']/xs:attribute[@name='author']">
+            <annox:annotate target="field">@javax.xml.bind.annotation.XmlAttribute(required=false, name="authorFieldHasBeenRenamed")</annox:annotate>
+        </jaxb:bindings>
+    </jaxb:bindings>
+
+</jaxb:bindings>

--- a/samples/groovy-dsl/xjc-version-ext-basics-annox/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-version-ext-basics-annox/src/main/schema/books.xsd
@@ -1,0 +1,25 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+            xmlns:annox="http://annox.dev.java.net"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            jaxb:extensionBindingPrefixes="annox"
+            jaxb:version="2.1">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-version-ext-mark-generated/build.gradle
+++ b/samples/groovy-dsl/xjc-version-ext-mark-generated/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.util.VersionNumber
 
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-ext-mark-generated/build.gradle
+++ b/samples/groovy-dsl/xjc-version-ext-mark-generated/build.gradle
@@ -1,0 +1,26 @@
+import org.gradle.util.VersionNumber
+
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    // -Xann javax.annotation.Generated  could be  jakarta.annotation.Generated
+    //   especially needed when xjcVersion = 3.0+ and targetVersion = 2.3
+    extraArgs.addAll '-mark-generated', '-noDate', '-Xann', 'javax.annotation.Generated'
+}
+
+dependencies {
+    // 2.3 is the default xjcVersion
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+
+    // -mark-generated: means you need to add dependency:
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
+}

--- a/samples/groovy-dsl/xjc-version-ext-mark-generated/settings.gradle
+++ b/samples/groovy-dsl/xjc-version-ext-mark-generated/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-version-ext-mark-generated'

--- a/samples/groovy-dsl/xjc-version-ext-mark-generated/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-version-ext-mark-generated/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/groovy-dsl/xjc-version-extensions/build.gradle
+++ b/samples/groovy-dsl/xjc-version-extensions/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.util.VersionNumber
 
 plugins {
     id('java')
-    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+    id('org.unbroken-dome.xjc') version '2.2.0-SNAPSHOT'
 }
 
 

--- a/samples/groovy-dsl/xjc-version-extensions/build.gradle
+++ b/samples/groovy-dsl/xjc-version-extensions/build.gradle
@@ -1,0 +1,28 @@
+import org.gradle.util.VersionNumber
+
+plugins {
+    id('java')
+    id('org.unbroken-dome.xjc') version '2.1.0-SNAPSHOT'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    // -episode: is managed by gradle-xjc-plugin already
+    extraArgs.addAll '-Xpropertyaccessors', '-mark-generated', '-Xlocator', '-Xsync-methods', '-Xinject-code'
+}
+
+dependencies {
+    // 2.3 is the default xjcVersion
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+
+    // -mark-generated: means you need to add dependency:
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
+
+    // -Xlocator: means you need to add dependency:
+    implementation 'com.sun.xml.bind:jaxb-core:2.3.0.1'
+}

--- a/samples/groovy-dsl/xjc-version-extensions/settings.gradle
+++ b/samples/groovy-dsl/xjc-version-extensions/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = 'xjc-version-extensions'

--- a/samples/groovy-dsl/xjc-version-extensions/src/main/schema/books.xjb
+++ b/samples/groovy-dsl/xjc-version-extensions/src/main/schema/books.xjb
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings
+        xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+        xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        xmlns:ci="http://jaxb.dev.java.net/plugin/code-injector"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd
+ http://jaxb.dev.java.net/plugin/code-injector"
+        jaxb:version="2.0">
+
+    <jaxb:bindings schemaLocation="books.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="org.unbroken_dome.gradle_xjc_plugin.samples.books.code_injector"/>
+        </jaxb:schemaBindings>
+
+        <jaxb:bindings node="/xsd:schema/xsd:complexType[@name='bookType']">
+            <ci:code>
+                <![CDATA[
+                public static Long injectedSystemCurrentTime() {
+                    return System.currentTimeMillis();
+                }
+                ]]>
+            </ci:code>
+        </jaxb:bindings>
+    </jaxb:bindings>
+
+</jaxb:bindings>

--- a/samples/groovy-dsl/xjc-version-extensions/src/main/schema/books.xsd
+++ b/samples/groovy-dsl/xjc-version-extensions/src/main/schema/books.xsd
@@ -1,0 +1,23 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jaxb.dev.java.net/plugin/code-injector ">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/basic/build.gradle.kts
+++ b/samples/kotlin-dsl/basic/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/kotlin-dsl/basic/build.gradle.kts
+++ b/samples/kotlin-dsl/basic/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/basic/build.gradle.kts
+++ b/samples/kotlin-dsl/basic/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/bindings/build.gradle.kts
+++ b/samples/kotlin-dsl/bindings/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/bindings/build.gradle.kts
+++ b/samples/kotlin-dsl/bindings/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("2.3")
+}
+
+
+dependencies {
+    implementation("javax.xml.bind:jaxb-api:2.3.0")
+}

--- a/samples/kotlin-dsl/bindings/settings.gradle.kts
+++ b/samples/kotlin-dsl/bindings/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "bindings"

--- a/samples/kotlin-dsl/bindings/src/main/schema/books.xjb
+++ b/samples/kotlin-dsl/bindings/src/main/schema/books.xjb
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings
+        xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+        xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+        jaxb:version="2.0">
+
+    <jaxb:bindings schemaLocation="books.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="org.unbroken_dome.gradle_xjc_plugin.samples.books.alt.package_name"/>
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+
+</jaxb:bindings>

--- a/samples/kotlin-dsl/bindings/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/bindings/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/bindings_jakarta/build.gradle.kts
+++ b/samples/kotlin-dsl/bindings_jakarta/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("3.0")
+}
+
+
+dependencies {
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:3.0.1")
+}

--- a/samples/kotlin-dsl/bindings_jakarta/build.gradle.kts
+++ b/samples/kotlin-dsl/bindings_jakarta/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/bindings_jakarta/settings.gradle.kts
+++ b/samples/kotlin-dsl/bindings_jakarta/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "bindings_jakarta"

--- a/samples/kotlin-dsl/bindings_jakarta/src/main/schema/books.xjb
+++ b/samples/kotlin-dsl/bindings_jakarta/src/main/schema/books.xjb
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings
+        xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+        xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jaxb https://jakarta.ee/xml/ns/jaxb/bindingschema_3_0.xsd"
+        jaxb:version="3.0">
+
+    <jaxb:bindings schemaLocation="books.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="org.unbroken_dome.gradle_xjc_plugin.samples.books.alt.package_name"/>
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+
+</jaxb:bindings>

--- a/samples/kotlin-dsl/bindings_jakarta/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/bindings_jakarta/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/catalogs/build.gradle.kts
+++ b/samples/kotlin-dsl/catalogs/build.gradle.kts
@@ -1,5 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/samples/kotlin-dsl/catalogs/consumer/build.gradle.kts
+++ b/samples/kotlin-dsl/catalogs/consumer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/catalogs/consumer/build.gradle.kts
+++ b/samples/kotlin-dsl/catalogs/consumer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/complete/build.gradle.kts
+++ b/samples/kotlin-dsl/complete/build.gradle.kts
@@ -1,5 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/samples/kotlin-dsl/complete/consumer/build.gradle.kts
+++ b/samples/kotlin-dsl/complete/consumer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/complete/consumer/build.gradle.kts
+++ b/samples/kotlin-dsl/complete/consumer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/complete/library/build.gradle.kts
+++ b/samples/kotlin-dsl/complete/library/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `java-library`
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/complete/library/build.gradle.kts
+++ b/samples/kotlin-dsl/complete/library/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `java-library`
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/doclocale/build.gradle.kts
+++ b/samples/kotlin-dsl/doclocale/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+xjc {
+    docLocale.set("it")
+}
+
+
+dependencies {
+    implementation("javax.xml.bind:jaxb-api:2.3.0")
+}

--- a/samples/kotlin-dsl/doclocale/build.gradle.kts
+++ b/samples/kotlin-dsl/doclocale/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/doclocale/settings.gradle.kts
+++ b/samples/kotlin-dsl/doclocale/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "doclocale"

--- a/samples/kotlin-dsl/doclocale/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/doclocale/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/episodes/build.gradle.kts
+++ b/samples/kotlin-dsl/episodes/build.gradle.kts
@@ -1,5 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/samples/kotlin-dsl/episodes/episode-consumer/build.gradle.kts
+++ b/samples/kotlin-dsl/episodes/episode-consumer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/episodes/episode-consumer/build.gradle.kts
+++ b/samples/kotlin-dsl/episodes/episode-consumer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/episodes/episode-producer/build.gradle.kts
+++ b/samples/kotlin-dsl/episodes/episode-producer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `java-library`
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/episodes/episode-producer/build.gradle.kts
+++ b/samples/kotlin-dsl/episodes/episode-producer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `java-library`
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/remote-schema/build.gradle.kts
+++ b/samples/kotlin-dsl/remote-schema/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/kotlin-dsl/remote-schema/build.gradle.kts
+++ b/samples/kotlin-dsl/remote-schema/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/remote-schema/build.gradle.kts
+++ b/samples/kotlin-dsl/remote-schema/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/wsdl/build.gradle.kts
+++ b/samples/kotlin-dsl/wsdl/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+xjc {
+    // This maybe inferred from the filename extension provided to XJC
+    extraArgs.addAll("-wsdl")
+}
+
+// With wsimport there is:
+//  cd src/main/schema
+//  mkdir out
+//  wsimport -verbose -keep -extension -b books.xjb -d out -wsdllocation "http://localhost/book/lookup/service" -Xdebug -XdisableAuthenticator books.wsdl
+// But this is outside the scope of XJB see other gradle plugins for wsimport support
+
+// XJC seems able to produce JAXB for *.wsdl and *.xsd but it includes all eligible
+//   file extensions from src/main/schema/** so when imports are used it appears to
+//   need those file to be relocated outside of src/main/schema so this is the reason
+//   for the schema_other directory
+
+dependencies {
+    implementation("javax.xml.bind:jaxb-api:2.3.0")
+}

--- a/samples/kotlin-dsl/wsdl/settings.gradle.kts
+++ b/samples/kotlin-dsl/wsdl/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "wsdl"

--- a/samples/kotlin-dsl/wsdl/src/main/schema/books.wsdl
+++ b/samples/kotlin-dsl/wsdl/src/main/schema/books.wsdl
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<wsdl:definitions
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup/service"
+        xmlns:look="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup"
+        xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+        xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+        name="BookLookupEndpointService"
+        targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup/service">
+
+
+    <wsdl:types>
+        <!-- the schema elements should be enumerated by XJC -->
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                   xmlns:look="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup"
+                   attributeFormDefault="unqualified"
+                   elementFormDefault="qualified"
+                   targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup/service"
+                   version="1.0">
+            <xsd:import namespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup" schemaLocation="lookup.xsd"/>
+        </xs:schema>
+    </wsdl:types>
+
+    <wsdl:message name="searchRequest">
+        <wsdl:part name="request" element="look:searchRequest"/>
+    </wsdl:message>
+
+    <wsdl:message name="searchResponse">
+        <wsdl:part name="result" element="look:searchResult"/>
+    </wsdl:message>
+
+    <wsdl:portType name="Search_PortType">
+        <wsdl:operation name="searchRequest">
+            <wsdl:input message="tns:searchRequest"/>
+            <wsdl:output message="tns:searchResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="Search_Binding" type="tns:Search_PortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="searchRequest">
+            <soap:operation soapAction="urn:searchAction"/>
+            <wsdl:input>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+                           use="literal"
+                           />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+                           use="literal"
+                           />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="Search_Service">
+        <wsdl:documentation>WSDL File Sample for Search_Service</wsdl:documentation>
+        <wsdl:port name="Search_Port" binding="tns:Search_Binding">
+            <soap:address location="http://localhost/gradle-xjc-plugin/samples/wsdl-basic/Search_Service/"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>

--- a/samples/kotlin-dsl/wsdl/src/main/schema/books.xjb
+++ b/samples/kotlin-dsl/wsdl/src/main/schema/books.xjb
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings
+        xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+        xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+        jaxb:version="2.0">
+
+    <jaxb:bindings schemaLocation="../schema_other/common.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="org.unbroken_dome.gradle_xjc_plugin.samples.books.alt.common"/>
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+
+    <jaxb:bindings schemaLocation="lookup.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="org.unbroken_dome.gradle_xjc_plugin.samples.books.alt.lookup"/>
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+
+</jaxb:bindings>

--- a/samples/kotlin-dsl/wsdl/src/main/schema/lookup.xsd
+++ b/samples/kotlin-dsl/wsdl/src/main/schema/lookup.xsd
@@ -1,0 +1,48 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:com="http://unbroken-dome.org/gradle-xjc-plugin/samples/common"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/lookup">
+
+    <xsd:import namespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/common" schemaLocation="../schema_other/common.xsd"/>
+    <xsd:import namespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books" schemaLocation="../schema_other/books.xsd"/>
+
+    <!--
+        <searchRequest>
+            <term>first term</term>
+            <term>second term</term>
+        </searchRequest>
+    -->
+    <xsd:element name="searchRequest">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element maxOccurs="unbounded" name="term" type="xsd:string"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+    <!--
+        <searchResult>
+            <searchResultItem>
+                <index>1</index>
+                <details>result info</details>
+                <bookId><bookIsbn>1234567890X</bookIsbn></bookId>
+            </searchResultItem>
+        </searchResult>
+    -->
+    <xsd:complexType name="searchResultItem">
+        <xsd:sequence>
+            <xsd:element name="index" type="xsd:positiveInteger"/>
+            <xsd:element name="details" type="xsd:string"/>
+            <xsd:element name="bookId" type="com:bookId" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="searchResult">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element minOccurs="0" maxOccurs="unbounded" name="result" type="tns:searchResultItem"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/wsdl/src/main/schema_other/books.xsd
+++ b/samples/kotlin-dsl/wsdl/src/main/schema_other/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/wsdl/src/main/schema_other/common.xsd
+++ b/samples/kotlin-dsl/wsdl/src/main/schema_other/common.xsd
@@ -1,0 +1,11 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/common"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/common">
+
+    <xsd:complexType name="bookId">
+        <xsd:attribute name="isbn" type="xsd:string"/>
+    </xsd:complexType>
+
+    <xsd:element name="bookIsbn" type="tns:bookId"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-plugin/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-plugin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/kotlin-dsl/xjc-plugin/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-plugin/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-plugin/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-plugin/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-tool-2_1-legacy/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_1-legacy/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("2.1")
+}
+
+
+dependencies {
+    // These legacy jars do not have any OSGi MANIFEST data,
+    //   that is what makes them legacy as plugin auto-detect works slightly different
+    implementation("javax.xml.bind:jaxb-api:2.1")
+
+    xjcTool("javax.xml.bind:jaxb-api:2.1")
+
+    xjcTool("com.sun.xml.bind:jaxb-xjc:2.1.17")
+    xjcTool("com.sun.xml.bind:jaxb-impl:2.1.17")
+    xjcTool("com.sun.xml.bind:jaxb-core:2.1.14")
+}

--- a/samples/kotlin-dsl/xjc-tool-2_1-legacy/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_1-legacy/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-tool-2_1-legacy/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_1-legacy/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-tool-2_1-legacy"

--- a/samples/kotlin-dsl/xjc-tool-2_1-legacy/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-tool-2_1-legacy/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-tool-2_2-legacy/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_2-legacy/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("2.2")
+}
+
+
+dependencies {
+    // These legacy jars do not have any OSGi MANIFEST data,
+    //   that is what makes them legacy as plugin auto-detect works slightly different
+    implementation("javax.xml.bind:jaxb-api:2.2.7")
+
+    xjcTool("javax.xml.bind:jaxb-api:2.2.7")
+
+    xjcTool("com.sun.xml.bind:jaxb-xjc:2.2.7")
+    xjcTool("com.sun.xml.bind:jaxb-impl:2.2.7")
+    xjcTool("com.sun.xml.bind:jaxb-core:2.2.7")
+}

--- a/samples/kotlin-dsl/xjc-tool-2_2-legacy/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_2-legacy/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-tool-2_2-legacy/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_2-legacy/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-tool-2_2-legacy"

--- a/samples/kotlin-dsl/xjc-tool-2_2-legacy/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-tool-2_2-legacy/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-tool-2_2/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_2/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-tool-2_2/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_2/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("2.2")
+}
+
+
+dependencies {
+    implementation("javax.xml.bind:jaxb-api:2.2.12")
+
+    xjcTool("javax.xml.bind:jaxb-api:2.2.12")
+
+    xjcTool("com.sun.xml.bind:jaxb-xjc:2.2.11")
+    xjcTool("com.sun.xml.bind:jaxb-impl:2.2.11")
+    xjcTool("com.sun.xml.bind:jaxb-core:2.2.11")
+}

--- a/samples/kotlin-dsl/xjc-tool-2_2/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_2/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-tool-2_2"

--- a/samples/kotlin-dsl/xjc-tool-2_2/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-tool-2_2/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-tool-2_3/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_3/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("2.3")
+}
+
+
+dependencies {
+    implementation("javax.xml.bind:jaxb-api:2.3.1")
+
+    xjcTool("com.sun.xml.bind:jaxb-xjc:2.3.8")
+}

--- a/samples/kotlin-dsl/xjc-tool-2_3/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_3/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-tool-2_3/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_3/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-tool-2_3"

--- a/samples/kotlin-dsl/xjc-tool-2_3/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-tool-2_3/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-tool-2_4/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_4/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-tool-2_4/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_4/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("2.4")
+}
+
+
+dependencies {
+    implementation("javax.xml.bind:jaxb-api:2.4.0-b180830.0359")
+    //implementation("javax.xml.bind:jaxb-api:2.3.1")
+    //implementation("javax.xml.bind:jaxb-api:2.2.12")
+
+    xjcTool("javax.xml.bind:jaxb-api:2.4.0-b180830.0359")
+
+    xjcTool("com.sun.xml.bind:jaxb-xjc:2.4.0-b180830.0438")
+    xjcTool("com.sun.xml.bind:jaxb-impl:2.4.0-b180830.0438")
+    xjcTool("com.sun.xml.bind:jaxb-core:2.3.0.1")  // there is no 2.4 version
+}

--- a/samples/kotlin-dsl/xjc-tool-2_4/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-2_4/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-tool-2_4"

--- a/samples/kotlin-dsl/xjc-tool-2_4/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-tool-2_4/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-tool-3_0-target-2_3/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-3_0-target-2_3/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("3.0")
+    targetVersion.set("2.3")
+}
+
+
+dependencies {
+    // Yes this looks wrong, based on XJC command line usage:
+    //    XJC 3.x/4.x itself does not need javax.xml.bind on its classpath,
+    //       it needs jakarta.xml.bind for generation.
+    //    JavaC does need to see javax.xml.bind as that is what is in the generated *.java
+
+    implementation("javax.xml.bind:jaxb-api:2.4.0-b180830.0359")
+
+    xjcTool("jakarta.xml.bind:jakarta.xml.bind-api:3.0.1")
+
+    xjcTool("com.sun.xml.bind:jaxb-xjc:3.0.2")
+}

--- a/samples/kotlin-dsl/xjc-tool-3_0-target-2_3/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-3_0-target-2_3/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-tool-3_0-target-2_3/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-3_0-target-2_3/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-tool-3_0-target-2_3"

--- a/samples/kotlin-dsl/xjc-tool-3_0-target-2_3/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-tool-3_0-target-2_3/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-tool-3_0/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-3_0/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("3.0")
+}
+
+
+dependencies {
+    // XJC 3.0 requires a different JAXB API artifact
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:3.0.1")
+
+    xjcTool("com.sun.xml.bind:jaxb-xjc:3.0.2")
+}

--- a/samples/kotlin-dsl/xjc-tool-3_0/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-3_0/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-tool-3_0/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-3_0/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-tool-3_0"

--- a/samples/kotlin-dsl/xjc-tool-3_0/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-tool-3_0/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-tool-4_0/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-4_0/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("4.0")
+}
+
+
+dependencies {
+    // XJC 3.0 requires a different JAXB API artifact
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
+
+    xjcTool("com.sun.xml.bind:jaxb-xjc:4.0.2")
+}

--- a/samples/kotlin-dsl/xjc-tool-4_0/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-4_0/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-tool-4_0/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-4_0/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-tool-4_0"

--- a/samples/kotlin-dsl/xjc-tool-4_0/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-tool-4_0/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-tool-future-latest/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-future-latest/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-tool-future-latest/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-future-latest/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("99.0")
+    xjcVersionUnsupportedStrategy.set("latest")
+}
+
+
+dependencies {
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
+
+    xjcTool("com.sun.xml.bind:jaxb-xjc:4.0.2")
+}

--- a/samples/kotlin-dsl/xjc-tool-future-latest/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-future-latest/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-tool-future-latest"

--- a/samples/kotlin-dsl/xjc-tool-future-latest/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-tool-future-latest/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-tool-future/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-future/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-tool-future/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-future/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("99.0")
+    //// This is testing build failure and error output due to not configuring:
+    //xjcVersionUnsupportedStrategy.set("auto-resolve")
+}
+
+
+dependencies {
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
+
+    // For this integration test to be JDK8 compatible this needs to be 3.x or older
+    // But doing that means that tests would never demonstrate itself working at the
+    // time the feature was added, as 3.x was supported already, so we only perform
+    // this test in JDK11+ while we don't yet support 4.x.
+    xjcTool("com.sun.xml.bind:jaxb-xjc:4.0.2")
+}

--- a/samples/kotlin-dsl/xjc-tool-future/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-tool-future/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-tool-future"

--- a/samples/kotlin-dsl/xjc-tool-future/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-tool-future/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-version-2_1-legacy/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_1-legacy/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("2.1")
+}
+
+
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitively
+    implementation("javax.xml.bind:jaxb-api:2.1")
+}

--- a/samples/kotlin-dsl/xjc-version-2_1-legacy/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_1-legacy/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-2_1-legacy/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_1-legacy/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-version-2_1-legacy"

--- a/samples/kotlin-dsl/xjc-version-2_1-legacy/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-version-2_1-legacy/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-version-2_2/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_2/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-2_2/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_2/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-2_2/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_2/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-2_2/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_2/build.gradle.kts
@@ -15,5 +15,6 @@ xjc {
 
 
 dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitively
     implementation("javax.xml.bind:jaxb-api:2.2.12")
 }

--- a/samples/kotlin-dsl/xjc-version-2_3/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_3/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-2_3/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_3/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("2.3")
+}
+
+
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitively
+    implementation("javax.xml.bind:jaxb-api:2.3.1")
+}

--- a/samples/kotlin-dsl/xjc-version-2_3/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_3/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-version-2_3"

--- a/samples/kotlin-dsl/xjc-version-2_3/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-version-2_3/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-version-2_4/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_4/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("2.4")
+}
+
+
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitively
+    implementation("javax.xml.bind:jaxb-api:2.4.0-b180830.0359")
+}

--- a/samples/kotlin-dsl/xjc-version-2_4/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_4/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-2_4/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-2_4/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-version-2_4"

--- a/samples/kotlin-dsl/xjc-version-2_4/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-version-2_4/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-version-3_0-target-2_3/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-3_0-target-2_3/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-3_0-target-2_3/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-3_0-target-2_3/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("3.0")
+    targetVersion.set("2.3")
+}
+
+
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitively
+    implementation("javax.xml.bind:jaxb-api:2.4.0-b180830.0359")
+}

--- a/samples/kotlin-dsl/xjc-version-3_0-target-2_3/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-3_0-target-2_3/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-version-3_0-target-2_3"

--- a/samples/kotlin-dsl/xjc-version-3_0-target-2_3/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-version-3_0-target-2_3/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-version-3_0/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-3_0/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-3_0/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-3_0/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-3_0/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-3_0/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-3_0/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-3_0/build.gradle.kts
@@ -15,6 +15,6 @@ xjc {
 
 
 dependencies {
-    // XJC 3.0 requires a different JAXB API artifact
-    implementation("jakarta.xml.bind:jakarta.xml.bind-api:3.0.0-RC3")
+    // This is still needed for Gradle to compile the generated Java and add transitively
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:3.0.1")
 }

--- a/samples/kotlin-dsl/xjc-version-4_0/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-4_0/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    xjcVersion.set("4.0")
+}
+
+
+dependencies {
+    // This is still needed for Gradle to compile the generated Java and add transitively
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
+}

--- a/samples/kotlin-dsl/xjc-version-4_0/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-4_0/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-4_0/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-4_0/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-version-4_0"

--- a/samples/kotlin-dsl/xjc-version-4_0/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-version-4_0/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-version-default/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-default/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+dependencies {
+    // 2.3 is the default xjcVersion
+    implementation("javax.xml.bind:jaxb-api:2.3.1")
+}

--- a/samples/kotlin-dsl/xjc-version-default/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-default/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-default/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-default/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-version-default"

--- a/samples/kotlin-dsl/xjc-version-default/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-version-default/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-version-ext-basics-annox/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-ext-basics-annox/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-ext-basics-annox/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-ext-basics-annox/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+xjc {
+    extraArgs.addAll("-Xannotate")
+    extension.set(true)
+}
+
+
+dependencies {
+    implementation("javax.xml.bind:jaxb-api:2.3.1")
+
+    // Picked 2.0.9 for middling Java8/XJC2.3 support but if you research and fixup your
+    // environment and dependencies here you could go newer or older with Java/XJC.
+    // -Xannotate: means you need to add dependency:
+    xjcClasspath("org.jvnet.jaxb:jaxb2-basics:2.0.9")
+    //xjcClasspath("org.jvnet.jaxb:jaxb-annox:2.0.9")
+    xjcClasspath("org.jvnet.jaxb:jaxb-basics-annotate:2.0.9")
+
+    // Don't forget to include your implementation dependencies for the annotations themselves
+    // A random arbitrary annotation library to demonstrate use, replace with the ones you described in XJB
+    implementation("javax.validation:validation-api:2.0.1.Final")
+}

--- a/samples/kotlin-dsl/xjc-version-ext-basics-annox/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-ext-basics-annox/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-version-ext-basics-annox"

--- a/samples/kotlin-dsl/xjc-version-ext-basics-annox/src/main/schema/books.xjb
+++ b/samples/kotlin-dsl/xjc-version-ext-basics-annox/src/main/schema/books.xjb
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings
+        xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+        xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:annox="http://annox.dev.java.net"
+        xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+        jaxb:version="2.1">
+
+    <jaxb:bindings schemaLocation="books.xsd" node="/xs:schema">
+        <jaxb:bindings node="//xs:complexType[@name='bookType']">
+            <annox:annotateClass>@javax.xml.bind.annotation.XmlRootElement(name="BookTypeHasBeenRenamed")</annox:annotateClass>
+        </jaxb:bindings>
+        <jaxb:bindings node="//xs:complexType[@name='bookType']/xs:attribute[@name='author']">
+            <annox:annotate target="field">@javax.xml.bind.annotation.XmlAttribute(required=false, name="authorFieldHasBeenRenamed")</annox:annotate>
+        </jaxb:bindings>
+    </jaxb:bindings>
+
+</jaxb:bindings>

--- a/samples/kotlin-dsl/xjc-version-ext-basics-annox/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-version-ext-basics-annox/src/main/schema/books.xsd
@@ -1,0 +1,25 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+            xmlns:annox="http://annox.dev.java.net"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            jaxb:extensionBindingPrefixes="annox"
+            jaxb:version="2.1">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-version-ext-mark-generated/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-ext-mark-generated/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-ext-mark-generated/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-ext-mark-generated/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+
+xjc {
+    // -Xann javax.annotation.Generated  could be  jakarta.annotation.Generated
+    //   especially needed when xjcVersion = 3.0+ and targetVersion = 2.3
+    extraArgs.addAll("-mark-generated", "-noDate", "-Xann", "javax.annotation.Generated")
+}
+
+
+dependencies {
+    // 2.3 is the default xjcVersion
+    implementation("javax.xml.bind:jaxb-api:2.3.1")
+
+    // -mark-generated: means you need to add dependency:
+    implementation("javax.annotation:javax.annotation-api:1.3.2")
+}

--- a/samples/kotlin-dsl/xjc-version-ext-mark-generated/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-ext-mark-generated/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-version-ext-mark-generated"

--- a/samples/kotlin-dsl/xjc-version-ext-mark-generated/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-version-ext-mark-generated/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/samples/kotlin-dsl/xjc-version-extensions/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-extensions/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+    id("org.unbroken-dome.xjc") version "2.2.0-SNAPSHOT"
 }
 
 

--- a/samples/kotlin-dsl/xjc-version-extensions/build.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-extensions/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    java
+    id("org.unbroken-dome.xjc") version "2.1.0-SNAPSHOT"
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+
+
+xjc {
+    // -episode: is managed by gradle-xjc-plugin already
+    extraArgs.addAll("-Xpropertyaccessors", "-mark-generated", "-Xlocator", "-Xsync-methods", "-Xinject-code")
+}
+
+
+dependencies {
+    // 2.3 is the default xjcVersion
+    implementation("javax.xml.bind:jaxb-api:2.3.1")
+
+    // -mark-generated: means you need to add dependency:
+    implementation("javax.annotation:javax.annotation-api:1.3.2")
+
+    // -Xlocator: means you need to add dependency:
+    implementation("com.sun.xml.bind:jaxb-core:2.3.0.1")
+}

--- a/samples/kotlin-dsl/xjc-version-extensions/settings.gradle.kts
+++ b/samples/kotlin-dsl/xjc-version-extensions/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+rootProject.name = "xjc-version-extensions"

--- a/samples/kotlin-dsl/xjc-version-extensions/src/main/schema/books.xjb
+++ b/samples/kotlin-dsl/xjc-version-extensions/src/main/schema/books.xjb
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings
+        xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+        xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        xmlns:ci="http://jaxb.dev.java.net/plugin/code-injector"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd
+ http://jaxb.dev.java.net/plugin/code-injector"
+        jaxb:version="2.0">
+
+    <jaxb:bindings schemaLocation="books.xsd">
+        <jaxb:schemaBindings>
+            <jaxb:package name="org.unbroken_dome.gradle_xjc_plugin.samples.books.code_injector"/>
+        </jaxb:schemaBindings>
+
+        <jaxb:bindings node="/xsd:schema/xsd:complexType[@name='bookType']">
+            <ci:code>
+                <![CDATA[
+                public static Long injectedSystemCurrentTime() {
+                    return System.currentTimeMillis();
+                }
+                ]]>
+            </ci:code>
+        </jaxb:bindings>
+    </jaxb:bindings>
+
+</jaxb:bindings>

--- a/samples/kotlin-dsl/xjc-version-extensions/src/main/schema/books.xsd
+++ b/samples/kotlin-dsl/xjc-version-extensions/src/main/schema/books.xsd
@@ -1,0 +1,21 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://unbroken-dome.org/gradle-xjc-plugin/samples/books"
+            targetNamespace="http://unbroken-dome.org/gradle-xjc-plugin/samples/books">
+
+    <xsd:complexType name="bookType">
+        <xsd:attribute name="title" type="xsd:string"/>
+        <xsd:attribute name="author" type="xsd:string"/>
+        <xsd:attribute name="publicationYear" type="xsd:gYear"/>
+    </xsd:complexType>
+
+    <xsd:element name="book" type="tns:bookType"/>
+
+    <xsd:complexType name="booksType">
+        <xsd:sequence>
+            <xsd:element ref="tns:book"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:element name="books" type="tns:booksType"/>
+
+</xsd:schema>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,3 +15,9 @@ pluginManagement {
 }
 
 rootProject.name = "gradle-xjc-plugin"
+
+if(System.getProperty("excludeDocsTasks") == null) {
+    include(":docs")
+} else {
+    logger.warn("systemProperty \"excludeDocsTasks\" is present, causing project :docs exclusion")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,15 @@
 pluginManagement {
 
     val kotlinVersion: String by settings
+    val testSetsVersion: String by settings
 
+    // Still needed while we support building this project before Gradle 7.6
     resolutionStrategy.eachPlugin {
         if (requested.id.namespace == "org.jetbrains.kotlin") {
             useVersion(kotlinVersion)
+        }
+        if (requested.id.id == "org.unbroken-dome.test-sets") {
+            useVersion(testSetsVersion)
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,32 @@ pluginManagement {
         if (requested.id.id == "org.unbroken-dome.test-sets") {
             useVersion(testSetsVersion)
         }
+        if (requested.id.id == "org.darrylmiles.repack.org.unbroken-dome.test-sets") {
+            useVersion(testSetsVersion)
+        }
+    }
+
+    repositories {
+        gradlePluginPortal()
+        maven {
+            url = uri("https://maven.pkg.github.com/dlmiles/gradle-testsets-plugin")
+            content {
+                // this repository only contains artifacts for specific groups
+                includeGroup("org.darrylmiles.repack.org.unbroken-dome.test-sets")
+                includeGroup("org.darrylmiles.repack.org.unbroken-dome")
+            }
+
+            val GITHUB_USERNAME = System.getenv("GITHUB_USERNAME") ?: System.getenv("GITHUB_ACTOR") ?: ""
+            val GITHUB_TOKEN = System.getenv("GITHUB_TOKEN") ?: System.getenv("GH_TOKEN") ?: ""
+            if(GITHUB_USERNAME.isEmpty()) { logger.warn("\$GITHUB_USERNAME not set") }
+            if(GITHUB_TOKEN.isEmpty()) { logger.warn("\$GITHUB_TOKEN not set") }
+            // Any valid GH credentials are necessary to download dependencies from GitHubPackages
+            credentials {
+                username = GITHUB_USERNAME
+                password = GITHUB_TOKEN
+            }
+        }
+        mavenCentral()
     }
 }
 

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/AbstractBasicIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/AbstractBasicIntegrationTest.kt
@@ -2,6 +2,7 @@ package org.unbrokendome.gradle.plugins.xjc
 
 import assertk.all
 import assertk.assertThat
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.platform.commons.annotation.Testable
@@ -19,7 +20,7 @@ import java.io.File
 
 abstract class AbstractBasicIntegrationTest {
 
-    fun test(runner: GradleRunner, projectDir: File, projectName: String) {
+    fun test(runner: GradleRunner, projectDir: File, projectName: String): BuildResult {
         val buildResult = runner.runGradle("build")
 
         assertThat(buildResult).all {
@@ -36,5 +37,7 @@ abstract class AbstractBasicIntegrationTest {
                     "org/unbroken_dome/gradle_xjc_plugin/samples/books/ObjectFactory.class"
                 )
             }
+
+        return buildResult
     }
 }

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/BindingsIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/BindingsIntegrationTest.kt
@@ -1,0 +1,41 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import assertk.all
+import assertk.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.*
+import org.unbrokendome.gradle.plugins.xjc.testutil.runGradle
+import java.io.File
+
+
+@UseSampleProject("bindings")
+class BindingsIntegrationTest {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        val projectName = "bindings"
+
+        val buildResult = runner.runGradle("build")
+
+        assertThat(buildResult).all {
+            task(":xjcGenerate").isSuccess()
+            task(":build").isSuccess()
+        }
+
+        assertThat(projectDir, "projectDir")
+            .resolve("build/libs/$projectName.jar")
+            .withJarFile {
+                containsEntries(
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/alt/package_name/BookType.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/alt/package_name/BooksType.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/alt/package_name/ObjectFactory.class"
+                )
+            }
+
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/BindingsJakartaIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/BindingsJakartaIntegrationTest.kt
@@ -1,0 +1,41 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import assertk.all
+import assertk.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.*
+import org.unbrokendome.gradle.plugins.xjc.testutil.runGradle
+import java.io.File
+
+
+@UseSampleProject("bindings_jakarta")
+class BindingsJakartaIntegrationTest {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        val projectName = "bindings_jakarta"
+
+        val buildResult = runner.runGradle("build")
+
+        assertThat(buildResult).all {
+            task(":xjcGenerate").isSuccess()
+            task(":build").isSuccess()
+        }
+
+        assertThat(projectDir, "projectDir")
+            .resolve("build/libs/$projectName.jar")
+            .withJarFile {
+                containsEntries(
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/alt/package_name/BookType.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/alt/package_name/BooksType.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/alt/package_name/ObjectFactory.class"
+                )
+            }
+
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/CatalogsWithCleanIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/CatalogsWithCleanIntegrationTest.kt
@@ -1,0 +1,64 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import assertk.all
+import assertk.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.containsEntries
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.containsEntry
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.isSuccess
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.resolve
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.task
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.withJarFile
+import org.unbrokendome.gradle.plugins.xjc.testutil.runGradle
+import java.io.File
+
+
+@UseSampleProject("catalogs")
+class CatalogsWithCleanIntegrationTest {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        val buildResult = runner.runGradle("build")
+
+        assertThat(buildResult).all {
+            task(":schema-library:build").isSuccess()
+            task(":consumer:xjcGenerate").isSuccess()
+            task(":consumer:build").isSuccess()
+        }
+
+        assertThat(projectDir, "projectDir")
+            .resolve("schema-library/build/libs/schema-library.jar")
+            .withJarFile {
+                containsEntry("schema/books.xsd")
+            }
+
+        assertThat(projectDir, "projectDir")
+            .resolve("consumer/build/libs/consumer.jar")
+            .withJarFile {
+                containsEntries(
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/BookType.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/BooksType.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/ObjectFactory.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/bookshelf/Bookshelf.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/bookshelf/ObjectFactory.class"
+                )
+            }
+
+        // It has been observed that clean fails to delete the schema-library\build\libs\schema-library.jar
+        //  after Gradle should have finished all processing with it.
+        // Note this maybe a Windows platform issue only, as by default you can't
+        //  unlink a file with an open file handle on it.
+        var cleanResult = runner.runGradle("clean")
+
+        assertThat(cleanResult).all {
+            task(":schema-library:clean").isSuccess()
+            task(":consumer:clean").isSuccess()
+        }
+
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/ConfigurationCacheIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/ConfigurationCacheIntegrationTest.kt
@@ -1,0 +1,40 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.output
+import org.unbrokendome.gradle.plugins.xjc.testutil.runGradle
+import java.io.File
+
+
+@UseSampleProject("basic")
+class ConfigurationCacheIntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+
+        val projectName = "basic"
+        val buildResult = runner.runGradle("--configuration-cache", "build")
+        checkTaskSuccess(buildResult)
+        checkOutputJar(projectDir, projectName)
+
+        assertThat(buildResult).all {
+            output().contains("Configuration cache entry stored.")
+        }
+
+
+        val maybeCachedBuildResult = runner.runGradle("--configuration-cache", "build")
+        checkTaskUpToDate(maybeCachedBuildResult)
+
+        assertThat(maybeCachedBuildResult).all {
+            output().contains("Configuration cache entry reused.")
+        }
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/DoclocaleIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/DoclocaleIntegrationTest.kt
@@ -1,0 +1,19 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("doclocale")
+class DoclocaleIntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "doclocale")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/GradleVersionCompatibilityIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/GradleVersionCompatibilityIntegrationTest.kt
@@ -17,7 +17,7 @@ import org.unbrokendome.gradle.plugins.xjc.testutil.runGradle
 import java.io.File
 
 
-const val AllGradleVersions = "6.6.1, 6.5.1, 6.4.1, 6.3, 6.2.2, 6.1.1, 6.0.1, 5.6.4, 5.6"
+const val AllGradleVersions =  "8.0.2, 7.6.1, 7.5.1, 7.4.2, 7.3.3, 7.2, 7.1.1, 7.0.2, 6.9.4, 6.8.2, 6.7.1, 6.6.1, 6.5.1, 6.4.1, 6.3, 6.2.2, 6.1.1, 6.0.1, 5.6.4, 5.6"
 
 
 @GradleIntegrationTest

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/GradleVersionCompatibilityIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/GradleVersionCompatibilityIntegrationTest.kt
@@ -17,7 +17,7 @@ import org.unbrokendome.gradle.plugins.xjc.testutil.runGradle
 import java.io.File
 
 
-const val AllGradleVersions =  "8.0.2, 7.6.1, 7.5.1, 7.4.2, 7.3.3, 7.2, 7.1.1, 7.0.2, 6.9.4, 6.8.2, 6.7.1, 6.6.1, 6.5.1, 6.4.1, 6.3, 6.2.2, 6.1.1, 6.0.1, 5.6.4, 5.6"
+const val AllGradleVersions =  "8.5, 8.4, 8.3, 8.2.1, 8.1.1, 8.0.2, 7.6.3, 7.5.1, 7.4.2, 7.3.3, 7.2, 7.1.1, 7.0.2, 6.9.4, 6.8.3, 6.7.1, 6.6.1, 6.5.1, 6.4.1, 6.3, 6.2.2, 6.1.1, 6.0.1, 5.6.4, 5.6"
 
 
 @GradleIntegrationTest

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/WsdlIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/WsdlIntegrationTest.kt
@@ -1,0 +1,43 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import assertk.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.containsEntries
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.resolve
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.withJarFile
+import java.io.File
+
+
+@UseSampleProject("wsdl")
+class WsdlIntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        val projectName = "wsdl"
+
+        super.test(runner, projectDir, projectName)
+
+        assertThat(projectDir, "projectDir")
+            .resolve("build/libs/$projectName.jar")
+            .withJarFile {
+                containsEntries(
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/BookType.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/BooksType.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/ObjectFactory.class",
+
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/alt/common/BookId.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/alt/common/ObjectFactory.class",
+
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/alt/lookup/ObjectFactory.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/alt/lookup/SearchRequest.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/alt/lookup/SearchResult.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/alt/lookup/SearchResultItem.class"
+                )
+            }
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPluginIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPluginIntegrationTest.kt
@@ -6,7 +6,6 @@ import assertk.assertions.contains
 import assertk.assertions.containsAll
 import assertk.assertions.extracting
 import assertk.assertions.isFile
-import jdk.nashorn.internal.runtime.regexp.joni.constants.AsmConstants
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.platform.commons.annotation.Testable
 import org.objectweb.asm.ClassReader

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool21LegacyIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool21LegacyIntegrationTest.kt
@@ -1,0 +1,19 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("xjc-tool-2_1-legacy")
+class XjcTool21LegacyIntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "xjc-tool-2_1-legacy")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool22IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool22IntegrationTest.kt
@@ -1,0 +1,19 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("xjc-tool-2_2")
+class XjcTool22IntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "xjc-tool-2_2")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool22LegacyIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool22LegacyIntegrationTest.kt
@@ -1,0 +1,20 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.AbstractBasicIntegrationTest
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("xjc-tool-2_2-legacy")
+class XjcTool22LegacyIntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "xjc-tool-2_2-legacy")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool23IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool23IntegrationTest.kt
@@ -1,0 +1,19 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("xjc-tool-2_3")
+class XjcTool23IntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "xjc-tool-2_3")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool24IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool24IntegrationTest.kt
@@ -1,0 +1,19 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("xjc-tool-2_4")
+class XjcTool24IntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "xjc-tool-2_4")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool30IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool30IntegrationTest.kt
@@ -1,0 +1,19 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("xjc-tool-3_0")
+class XjcTool30IntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "xjc-tool-3_0")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool30IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool30IntegrationTest.kt
@@ -1,10 +1,15 @@
 package org.unbrokendome.gradle.plugins.xjc
 
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.platform.commons.annotation.Testable
 import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
 import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
 import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.resolve
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.withReadTextFile
 import java.io.File
 
 
@@ -14,6 +19,16 @@ class XjcTool30IntegrationTest : AbstractBasicIntegrationTest() {
     @TestEachDslFlavor
     @Testable
     fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
-        super.test(runner, projectDir, "xjc-tool-3_0")
+        val projectName = "xjc-tool-3_0"
+
+        super.test(runner, projectDir, projectName)
+
+        assertThat(projectDir, "projectDir")
+            .resolve("build/generated/sources/xjc/java/main/org/unbroken_dome/gradle_xjc_plugin/samples/books/ObjectFactory.java")
+            .withReadTextFile {
+                contains("jakarta.xml.bind.annotation.XmlRegistry")
+                doesNotContain("javax.xml.bind")
+            }
+
     }
 }

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool30Target23IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool30Target23IntegrationTest.kt
@@ -1,0 +1,33 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.resolve
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.withReadTextFile
+import java.io.File
+
+
+@UseSampleProject("xjc-tool-3_0-target-2_3")
+class XjcTool30Target23IntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        val projectName = "xjc-tool-3_0-target-2_3"
+
+        super.test(runner, projectDir, projectName)
+
+        assertThat(projectDir, "projectDir")
+            .resolve("build/generated/sources/xjc/java/main/org/unbroken_dome/gradle_xjc_plugin/samples/books/ObjectFactory.java")
+            .withReadTextFile {
+                contains("javax.xml.bind.annotation.XmlRegistry")
+                doesNotContain("jakarta")
+            }
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool40IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcTool40IntegrationTest.kt
@@ -1,0 +1,23 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assumptions
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.JavaVersionUtil.Companion.javaVersionAtLeast
+import java.io.File
+
+
+@UseSampleProject("xjc-tool-4_0")
+class XjcTool40IntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        Assumptions.assumeTrue(javaVersionAtLeast(11), "Requires JDK11 runtime or above due to the XJC Tool bytecode version requirement")
+
+        super.test(runner, projectDir, "xjc-tool-4_0")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcToolFutureIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcToolFutureIntegrationTest.kt
@@ -18,6 +18,7 @@ import java.io.File
 @UseSampleProject("xjc-tool-future")
 class XjcToolFutureIntegrationTest : AbstractBasicIntegrationTest() {
 
+    @Suppress("UNUSED_PARAMETER")
     // Disabled to enable this test with we ideally need to supply an XJC
     // Tool implementation that has a future version such as in the
     // MANIFEST.MF:

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcToolFutureIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcToolFutureIntegrationTest.kt
@@ -18,8 +18,14 @@ import java.io.File
 @UseSampleProject("xjc-tool-future")
 class XjcToolFutureIntegrationTest : AbstractBasicIntegrationTest() {
 
-    @TestEachDslFlavor
-    @Testable
+    // Disabled to enable this test with we ideally need to supply an XJC
+    // Tool implementation that has a future version such as in the
+    // MANIFEST.MF:
+    //  Specification-Version: 98.0
+    // Maybe it is possible to achieve this in the sample project tree
+    //  and have gradle build a subproject before using it to run this test.
+    //@TestEachDslFlavor
+    //@Testable
     fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
         Assumptions.assumeTrue(javaVersionAtLeast(11), "Requires JDK11 runtime or above due to the XJC Tool bytecode version requirement")
 

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcToolFutureIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcToolFutureIntegrationTest.kt
@@ -1,0 +1,23 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assumptions
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.JavaVersionUtil.Companion.javaVersionAtLeast
+import java.io.File
+
+
+@UseSampleProject("xjc-tool-future")
+class XjcToolFutureIntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        Assumptions.assumeTrue(javaVersionAtLeast(11), "Requires JDK11 runtime or above due to the XJC Tool bytecode version requirement")
+
+	super.test(runner, projectDir, "xjc-tool-future")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcToolFutureIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcToolFutureIntegrationTest.kt
@@ -1,12 +1,17 @@
 package org.unbrokendome.gradle.plugins.xjc
 
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assumptions
 import org.junit.platform.commons.annotation.Testable
 import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
 import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
 import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
 import org.unbrokendome.gradle.plugins.xjc.testutil.JavaVersionUtil.Companion.javaVersionAtLeast
+import org.unbrokendome.gradle.plugins.xjc.testutil.runGradle
 import java.io.File
 
 
@@ -18,6 +23,15 @@ class XjcToolFutureIntegrationTest : AbstractBasicIntegrationTest() {
     fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
         Assumptions.assumeTrue(javaVersionAtLeast(11), "Requires JDK11 runtime or above due to the XJC Tool bytecode version requirement")
 
-	super.test(runner, projectDir, "xjc-tool-future")
+        //val projectName = "xjc-tool-future"
+
+        val buildResult = runner.runGradle("build", expectFailure=true)
+
+        assertEquals(TaskOutcome.FAILED, buildResult.task(":xjcGenerate")?.outcome)
+        assertNull(buildResult.task(":build")?.outcome)
+
+        val msg = "xjcVersionUnsupportedStrategy"
+        val bf = buildResult.output.contains(msg)
+        Assertions.assertTrue(bf, "Expected message in build output log: $msg")
     }
 }

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcToolFutureLatestIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcToolFutureLatestIntegrationTest.kt
@@ -1,0 +1,30 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.JavaVersionUtil.Companion.javaVersionAtLeast
+import java.io.File
+
+
+@UseSampleProject("xjc-tool-future-latest")
+class XjcToolFutureLatestIntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        Assumptions.assumeTrue(javaVersionAtLeast(11), "Requires JDK11 runtime or above due to the XJC Tool bytecode version requirement")
+
+        val projectName = "xjc-tool-future-latest"
+
+        val buildResult = super.test(runner, projectDir, projectName)
+
+        val msg = "xjcVersionUnsupportedStrategy is set latest"
+        val bf = buildResult.output.contains(msg)
+        assertTrue(bf, "Expected message in build output log: $msg")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion21LegacyIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion21LegacyIntegrationTest.kt
@@ -1,0 +1,19 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("xjc-version-2_1-legacy")
+class XjcVersion21LegacyIntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "xjc-version-2_1-legacy")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion23IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion23IntegrationTest.kt
@@ -1,0 +1,19 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("xjc-version-2_3")
+class XjcVersion23IntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "xjc-version-2_3")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion24IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion24IntegrationTest.kt
@@ -1,0 +1,19 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("xjc-version-2_4")
+class XjcVersion24IntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "xjc-version-2_4")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion30IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion30IntegrationTest.kt
@@ -1,10 +1,15 @@
 package org.unbrokendome.gradle.plugins.xjc
 
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.platform.commons.annotation.Testable
 import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
 import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
 import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.resolve
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.withReadTextFile
 import java.io.File
 
 
@@ -14,6 +19,16 @@ class XjcVersion30IntegrationTest : AbstractBasicIntegrationTest() {
     @TestEachDslFlavor
     @Testable
     fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
-        super.test(runner, projectDir, "xjc-version-3_0")
+        val projectName = "xjc-version-3_0"
+
+        super.test(runner, projectDir, projectName)
+
+        assertThat(projectDir, "projectDir")
+            .resolve("build/generated/sources/xjc/java/main/org/unbroken_dome/gradle_xjc_plugin/samples/books/ObjectFactory.java")
+            .withReadTextFile {
+                contains("jakarta.xml.bind.annotation.XmlRegistry")
+                doesNotContain("javax.xml.bind")
+            }
+
     }
 }

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion30Target23IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion30Target23IntegrationTest.kt
@@ -1,0 +1,33 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.resolve
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.withReadTextFile
+import java.io.File
+
+
+@UseSampleProject("xjc-version-3_0-target-2_3")
+class XjcVersion30Target23IntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        val projectName = "xjc-version-3_0-target-2_3"
+
+        super.test(runner, projectDir, projectName)
+
+        assertThat(projectDir, "projectDir")
+            .resolve("build/generated/sources/xjc/java/main/org/unbroken_dome/gradle_xjc_plugin/samples/books/ObjectFactory.java")
+            .withReadTextFile {
+                contains("javax.xml.bind.annotation.XmlRegistry")
+                doesNotContain("jakarta")
+            }
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion40IntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersion40IntegrationTest.kt
@@ -1,0 +1,23 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assumptions
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.JavaVersionUtil.Companion.javaVersionAtLeast
+import java.io.File
+
+
+@UseSampleProject("xjc-version-4_0")
+class XjcVersion40IntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        Assumptions.assumeTrue(javaVersionAtLeast(11), "Requires JDK11 runtime or above due to the XJC Tool bytecode version requirement")
+
+        super.test(runner, projectDir, "xjc-version-4_0")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersionDefaultIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersionDefaultIntegrationTest.kt
@@ -1,0 +1,19 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("xjc-version-default")
+class XjcVersionDefaultIntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "xjc-version-default")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersionExtBasicsAnnoxIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersionExtBasicsAnnoxIntegrationTest.kt
@@ -1,0 +1,38 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import assertk.assertThat
+import assertk.assertions.contains
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.resolve
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.withReadTextFile
+import java.io.File
+
+
+@UseSampleProject("xjc-version-ext-basics-annox")
+class XjcVersionExtBasicsAnnoxIntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        val projectName = "xjc-version-ext-basics-annox"
+
+        super.test(runner, projectDir, projectName)
+
+        assertThat(projectDir, "projectDir")
+            .resolve("build/generated/sources/xjc/java/main/org/unbroken_dome/gradle_xjc_plugin/samples/books/BookType.java")
+            .withReadTextFile {
+                contains("BookTypeHasBeenRenamed")
+            }
+
+        assertThat(projectDir, "projectDir")
+            .resolve("build/generated/sources/xjc/java/main/org/unbroken_dome/gradle_xjc_plugin/samples/books/BookType.java")
+            .withReadTextFile {
+                contains("authorFieldHasBeenRenamed")
+            }
+    }
+
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersionExtMarkGeneratedIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersionExtMarkGeneratedIntegrationTest.kt
@@ -1,0 +1,19 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import java.io.File
+
+
+@UseSampleProject("xjc-version-ext-mark-generated")
+class XjcVersionExtMarkGeneratedIntegrationTest : AbstractBasicIntegrationTest() {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        super.test(runner, projectDir, "xjc-version-ext-mark-generated")
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersionExtensionsIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcVersionExtensionsIntegrationTest.kt
@@ -1,0 +1,63 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.platform.commons.annotation.Testable
+import org.unbrokendome.gradle.plugins.xjc.samples.TestEachDslFlavor
+import org.unbrokendome.gradle.plugins.xjc.samples.UseSampleProject
+import org.unbrokendome.gradle.plugins.xjc.testutil.GradleProjectDir
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.*
+import org.unbrokendome.gradle.plugins.xjc.testutil.runGradle
+import java.io.File
+
+
+@UseSampleProject("xjc-version-extensions")
+class XjcVersionExtensionsIntegrationTest {
+
+    @TestEachDslFlavor
+    @Testable
+    fun test(runner: GradleRunner, @GradleProjectDir projectDir: File) {
+        val projectName = "xjc-version-extensions"
+
+        val buildResult = runner.runGradle("build")
+
+        assertThat(buildResult).all {
+            task(":xjcGenerate").isSuccess()
+            task(":build").isSuccess()
+        }
+
+        assertThat(projectDir, "projectDir")
+            .resolve("build/libs/$projectName.jar")
+            .withJarFile {
+                containsEntries(
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/code_injector/BookType.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/code_injector/BooksType.class",
+                    "org/unbroken_dome/gradle_xjc_plugin/samples/books/code_injector/ObjectFactory.class"
+                )
+            }
+
+        assertThat(projectDir, "projectDir")
+            .resolve("build/generated/sources/xjc/java/main/org/unbroken_dome/gradle_xjc_plugin/samples/books/code_injector/ObjectFactory.java")
+            .withReadTextFile {
+                contains("javax.xml.bind.annotation.XmlRegistry")
+                doesNotContain("jakarta")
+                contains("javax.annotation.Generated")
+                contains("@Generated(")
+            }
+
+        assertThat(projectDir, "projectDir")
+            .resolve("build/generated/sources/xjc/java/main/org/unbroken_dome/gradle_xjc_plugin/samples/books/code_injector/BookType.java")
+            .withReadTextFile {
+                contains("javax.xml.bind.annotation.XmlType")
+                doesNotContain("jakarta")
+                contains("javax.annotation.Generated")
+                contains("@Generated(")
+                contains("com.sun.xml.bind.annotation.XmlLocation")
+                contains(" synchronized ")
+                contains(" injectedSystemCurrentTime")
+            }
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/GradleVersionsExtension.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/GradleVersionsExtension.kt
@@ -55,7 +55,11 @@ class GradleVersionsExtension : TestTemplateInvocationContextProvider {
             return Stream.empty()
         }
 
-        return versions.asSequence()
+        // support for CI canary testing -Dorg.unbrokendome.gradle.plugins.xjc.testutil.GradleVersions=99.0,98.0.1
+        val propValue = System.getProperty(GradleVersions::class.java.name)?.trim()
+        val versionsAfterPropertyOverride = if(propValue?.isNotBlank() == true) listOf(propValue) else versions
+
+        return versionsAfterPropertyOverride.asSequence()
             .flatMap { gradleVersions ->
                 gradleVersions.splitToSequence(',').map { it.trim() }
             }

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/JavaVersionUtil.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/JavaVersionUtil.kt
@@ -1,0 +1,16 @@
+package org.unbrokendome.gradle.plugins.xjc.testutil
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import java.math.BigDecimal
+
+class JavaVersionUtil {
+
+    companion object {
+        fun javaVersionAtLeast(minimumVersion: Int): Boolean {
+            val javaVersion = System.getProperty("java.version")?.split(".")?.subList(0, 2)?.joinToString(".")    // "1.8" => "1.8"
+            assertNotNull(javaVersion)
+            return BigDecimal(javaVersion) >= BigDecimal(minimumVersion)
+        }
+    }
+
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/BuildResult.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/BuildResult.kt
@@ -17,6 +17,12 @@ fun Assert<BuildResult>.task(taskPath: String) =
     }
 
 
+fun Assert<BuildResult>.output() =
+    transform(name = "output") { actual ->
+        actual.output
+    }
+
+
 val Assert<BuildTask>.outcome: Assert<TaskOutcome>
     get() = transform(name = "$name outcome") { actual ->
         actual.outcome

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/BuildResult.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/BuildResult.kt
@@ -13,7 +13,7 @@ import org.gradle.testkit.runner.TaskOutcome
 fun Assert<BuildResult>.task(taskPath: String) =
     transform(name = "task $taskPath") { actual ->
         actual.task(taskPath)
-            ?: expected("to include task '$taskPath', but was: ${show(actual.tasks.map { it.path })}")
+            ?: this.expected("to include task '$taskPath', but was: ${show(actual.tasks.map { it.path })}")
     }
 
 

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/ReadTextFile.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/ReadTextFile.kt
@@ -1,0 +1,15 @@
+package org.unbrokendome.gradle.plugins.xjc.testutil.assertions
+
+import assertk.Assert
+import assertk.all
+import assertk.assertions.isFile
+import java.io.File
+
+
+fun Assert<File>.withReadTextFile(block: Assert<String>.() -> Unit) {
+    isFile()
+    given { actual ->
+        val text = actual.readText(Charsets.UTF_8)
+        assertThat(text, "readText:$name").all(block)
+    }
+}

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcExtension.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcExtension.kt
@@ -21,7 +21,7 @@ interface XjcExtension : XjcGeneratorOptions {
      * The version of the XJC _tool_ to use.
      *
      * This will influence the version of the XJC compiler that is used, but not (directly) the parameters
-     * that are passed to it. Valid values are `2.2`, `2.3`, `2.4` and `3.0`.
+     * that are passed to it. Valid values are `2.2`, `2.3`, `2.4`, `3.0` and `4.0`.
      *
      * The value of this property only influences the set of
      * [defaultDependencies][org.gradle.api.artifacts.Configuration.defaultDependencies] on the global `xjcTool`

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcExtension.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcExtension.kt
@@ -14,6 +14,7 @@ interface XjcExtension : XjcGeneratorOptions {
     companion object {
         const val DEFAULT_XJC_VERSION = "2.3"
         const val DEFAULT_SRC_DIR_NAME = "schema"
+        const val DEFAULT_XJC_VERSION_UNSUPPORTED_STRATEGY = "default"
     }
 
     /**
@@ -30,6 +31,34 @@ interface XjcExtension : XjcGeneratorOptions {
      * The default is currently `2.3`, but this may change in future versions of the plugin.
      */
     val xjcVersion: Property<String>
+
+    /**
+     * This setting exists to support newer versions of the XJC tool than the gradle plugin has been
+     *  tested with and officially supports as listed in the `xjcVersion` setting.
+     *
+     * This setting exists because doing this silently is probably not what all users would want by default.
+     * Without this setting configured the plugin will error informing you the XJC tool is newer than that
+     *  officially supported by the plugin and the existence of this setting provides a strategy that may
+     *  be able to resolve the build failure situation.
+     *
+     * This forces the documentation to be read and an administrative decision to be made for your
+     *  project concerning any risks for using unsupported XJC tooling versions in this way.
+     * If this setting is configured to something other than `default` you are advised to manually check
+     *  the generated output conforms to your expectations.
+     *
+     * If you wish the plugin to continue configure this setting to `auto-resolve`.
+     *
+     * Possible values might be:
+     *   `default` This will auto-detect XJC tool version and only allow supported versions to proceed.
+     *   `auto-resolve` This will behave as `default` first, if `default` fails then proceed using `latest`.
+     *     This strategy is anticipated to be the action most users want in the situation.
+     *   `latest` to use the strategy for the latest supported version.  As listed in `xjcVersion`.
+     *   `2.3` would force a specific strategy of a specific XJC tool version.
+     *     Any string value also valid for `xjcVersion` is allowed, `2.3` is an example of one of those values.
+     *
+     * Default is `default`.
+     */
+    val xjcVersionUnsupportedStrategy: Property<String>
 
     /**
      * The conventional name of the XJC source directories.
@@ -56,6 +85,9 @@ interface XjcExtension : XjcGeneratorOptions {
 private fun XjcExtension.setFromProjectProperties(project: Project) = apply {
     xjcVersion.set(
         project.providerFromProjectProperty("xjc.xjcVersion", XjcExtension.DEFAULT_XJC_VERSION)
+    )
+    xjcVersionUnsupportedStrategy.set(
+        project.providerFromProjectProperty("xjc.xjcVersionUnsupportedStrategy", XjcExtension.DEFAULT_XJC_VERSION_UNSUPPORTED_STRATEGY)
     )
     srcDirName.set(
         project.providerFromProjectProperty("xjc.srcDirName", XjcExtension.DEFAULT_SRC_DIR_NAME)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcExtension.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcExtension.kt
@@ -21,7 +21,7 @@ interface XjcExtension : XjcGeneratorOptions {
      * The version of the XJC _tool_ to use.
      *
      * This will influence the version of the XJC compiler that is used, but not (directly) the parameters
-     * that are passed to it. Valid values are `2.2`, `2.3`, `2.4`, `3.0` and `4.0`.
+     * that are passed to it. Valid values are `2.1`, `2.2`, `2.3`, `2.4`, `3.0` and `4.0`.
      *
      * The value of this property only influences the set of
      * [defaultDependencies][org.gradle.api.artifacts.Configuration.defaultDependencies] on the global `xjcTool`
@@ -53,6 +53,7 @@ interface XjcExtension : XjcGeneratorOptions {
      *   `auto-resolve` This will behave as `default` first, if `default` fails then proceed using `latest`.
      *     This strategy is anticipated to be the action most users want in the situation.
      *   `latest` to use the strategy for the latest supported version.  As listed in `xjcVersion`.
+     *   `legacy-latest` to use the latest known legacy strategy as used for 2.1 XJC tools.
      *   `2.3` would force a specific strategy of a specific XJC tool version.
      *     Any string value also valid for `xjcVersion` is allowed, `2.3` is an example of one of those values.
      *

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcExtension.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcExtension.kt
@@ -21,7 +21,7 @@ interface XjcExtension : XjcGeneratorOptions {
      * The version of the XJC _tool_ to use.
      *
      * This will influence the version of the XJC compiler that is used, but not (directly) the parameters
-     * that are passed to it. Valid values are `2.2`, `2.3` and `3.0`.
+     * that are passed to it. Valid values are `2.2`, `2.3`, `2.4` and `3.0`.
      *
      * The value of this property only influences the set of
      * [defaultDependencies][org.gradle.api.artifacts.Configuration.defaultDependencies] on the global `xjcTool`

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.kt
@@ -44,7 +44,8 @@ abstract class XjcGenerate
             "2.2" to "org.unbrokendome.gradle.plugins.xjc.work.xjc22.XjcGeneratorWorkAction",
             "2.3" to "org.unbrokendome.gradle.plugins.xjc.work.xjc23.XjcGeneratorWorkAction",
             "2.4" to "org.unbrokendome.gradle.plugins.xjc.work.xjc24.XjcGeneratorWorkAction",
-            "3.0" to "org.unbrokendome.gradle.plugins.xjc.work.xjc30.XjcGeneratorWorkAction"
+            "3.0" to "org.unbrokendome.gradle.plugins.xjc.work.xjc30.XjcGeneratorWorkAction",
+            "4.0" to "org.unbrokendome.gradle.plugins.xjc.work.xjc40.XjcGeneratorWorkAction"
         )
         private val HIGHEST_SUPPORTED_VERSION = WorkActionClassNamesByVersion.keys.max()
     }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.kt
@@ -59,6 +59,11 @@ abstract class XjcGenerate
             assert(LEGACY_LATEST_SUPPORTED_VERSION.isNotEmpty())
             assert(HIGHEST_SUPPORTED_VERSION.isNotEmpty())
         }
+
+        fun resolveArtifactsForMavenUri(configuration: Configuration): MutableList<SerializableResolvedArtifact> {
+            val artifacts = configuration.resolvedConfiguration.lenientConfiguration.artifacts
+            return artifacts.map { SerializableResolvedArtifact(it) }.toMutableList()
+        }
     }
 
 
@@ -124,8 +129,8 @@ abstract class XjcGenerate
     /**
      * A [Configuration] to be used for catalog resolution with the `maven:` URI scheme.
      */
-    @get:[InputFiles Optional Classpath]
-    abstract val catalogResolutionClasspath: Property<Configuration>
+    @get:[Input Optional]
+    abstract val catalogSerializableResolvedArtifact: ListProperty<SerializableResolvedArtifact>
 
 
     /**
@@ -329,12 +334,7 @@ abstract class XjcGenerate
         parameters.bindingFiles.setFrom(bindingFiles)
         parameters.pluginClasspath.setFrom(pluginClasspath)
         parameters.catalogFiles.setFrom(catalogs)
-        parameters.catalogResolvedArtifacts.set(
-            catalogResolutionClasspath.map { configuration ->
-                configuration.resolvedConfiguration.lenientConfiguration.artifacts
-                    .map { SerializableResolvedArtifact(it) }
-            }
-        )
+        parameters.catalogResolvedArtifacts.set(catalogSerializableResolvedArtifact)
         parameters.episodes.setFrom(episodes)
         parameters.targetPackage.set(targetPackage)
         parameters.encoding.set(encoding)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.kt
@@ -43,6 +43,7 @@ abstract class XjcGenerate
         private val WorkActionClassNamesByVersion = mapOf(
             "2.2" to "org.unbrokendome.gradle.plugins.xjc.work.xjc22.XjcGeneratorWorkAction",
             "2.3" to "org.unbrokendome.gradle.plugins.xjc.work.xjc23.XjcGeneratorWorkAction",
+            "2.4" to "org.unbrokendome.gradle.plugins.xjc.work.xjc24.XjcGeneratorWorkAction",
             "3.0" to "org.unbrokendome.gradle.plugins.xjc.work.xjc30.XjcGeneratorWorkAction"
         )
         private val HIGHEST_SUPPORTED_VERSION = WorkActionClassNamesByVersion.keys.max()

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.kt
@@ -41,12 +41,17 @@ abstract class XjcGenerate
          * Used to select the correct WorkAction for a given JAXB spec version.
          */
         private val WorkActionClassNamesByVersion = mapOf(
+            "2.1" to "org.unbrokendome.gradle.plugins.xjc.work.xjc21.XjcGeneratorLegacyWorkAction",
             "2.2" to "org.unbrokendome.gradle.plugins.xjc.work.xjc22.XjcGeneratorWorkAction",
             "2.3" to "org.unbrokendome.gradle.plugins.xjc.work.xjc23.XjcGeneratorWorkAction",
             "2.4" to "org.unbrokendome.gradle.plugins.xjc.work.xjc24.XjcGeneratorWorkAction",
             "3.0" to "org.unbrokendome.gradle.plugins.xjc.work.xjc30.XjcGeneratorWorkAction",
             "4.0" to "org.unbrokendome.gradle.plugins.xjc.work.xjc40.XjcGeneratorWorkAction"
         )
+        private val LEGACY_LATEST_SUPPORTED_VERSION = WorkActionClassNamesByVersion.entries
+            .filter { it.value.endsWith("LegacyWorkAction") }
+            .map { it.key }
+            .max()
         private val HIGHEST_SUPPORTED_VERSION = WorkActionClassNamesByVersion.keys.max()
     }
 
@@ -188,6 +193,7 @@ abstract class XjcGenerate
      *   `auto-resolve` This will behave as `default` first, if `default` fails then proceed using `latest`.
      *     This strategy is anticipated to be the action most users want in the situation.
      *   `latest` to use the strategy for the latest supported version.  As listed in `xjcVersion`.
+     *   `legacy-latest` to use the latest known legacy strategy as used for 2.1 XJC tools.
      *   `2.3` would force a specific strategy of a specific XJC tool version.
      *     Any string value also valid for `xjcVersion` is allowed, `2.3` is an example of one of those values.
      *
@@ -257,6 +263,8 @@ abstract class XjcGenerate
         var xjcVersion: String?
         if("latest".equals(xjcVersionStrategy, true))
             xjcVersion = HIGHEST_SUPPORTED_VERSION
+        else if("legacy-latest".equals(xjcVersionStrategy, true))
+            xjcVersion = LEGACY_LATEST_SUPPORTED_VERSION
         else if(!isDefault && !isAutoResolve && xjcVersionStrategy.isNotEmpty())
             xjcVersion = xjcVersionStrategy
         else    // "default" || "auto-resolve" || empty || null

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerate.kt
@@ -51,8 +51,14 @@ abstract class XjcGenerate
         private val LEGACY_LATEST_SUPPORTED_VERSION = WorkActionClassNamesByVersion.entries
             .filter { it.value.endsWith("LegacyWorkAction") }
             .map { it.key }
-            .max()
-        private val HIGHEST_SUPPORTED_VERSION = WorkActionClassNamesByVersion.keys.max()
+            .fold("") { acc, it -> if (acc > it) acc else it }  // .max() but supported by all kotlin versions
+        private val HIGHEST_SUPPORTED_VERSION = WorkActionClassNamesByVersion.keys
+            .fold("") { acc, it -> if (acc > it) acc else it }  // .max() but supported by all kotlin versions
+
+        init {
+            assert(LEGACY_LATEST_SUPPORTED_VERSION.isNotEmpty())
+            assert(HIGHEST_SUPPORTED_VERSION.isNotEmpty())
+        }
     }
 
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGeneratorOptions.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGeneratorOptions.kt
@@ -10,7 +10,6 @@ import org.unbrokendome.gradle.plugins.xjc.internal.XjcGeneratorFlags
 import org.unbrokendome.gradle.plugins.xjc.internal.booleanProviderFromProjectProperty
 import org.unbrokendome.gradle.plugins.xjc.internal.providerFromProjectProperty
 import java.util.EnumSet
-import java.util.Locale
 
 
 /**
@@ -42,7 +41,7 @@ interface XjcGeneratorOptions {
      * the JVM's default locale to the given one before calling XJC, and switch it back afterwards.
      */
     @get:[Input Optional]
-    val docLocale: Property<Locale>
+    val docLocale: Property<String>
 
     /**
      * If `true`, perform strict schema validation.
@@ -126,7 +125,7 @@ internal fun XjcGeneratorOptions.setFromProjectProperties(project: Project) = ap
         project.providerFromProjectProperty("xjc.encoding", "UTF-8")
     )
     docLocale.set(
-        project.providerFromProjectProperty("xjc.docLocale", Locale::forLanguageTag)
+        project.providerFromProjectProperty("xjc.docLocale")
     )
     strictCheck.set(
         project.booleanProviderFromProjectProperty("xjc.strictCheck", true)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
@@ -29,6 +29,12 @@ class XjcPlugin : Plugin<Project> {
         val XJC_GLOBAL_CATALOG_RESOLUTION_CONFIGURATION_NAME = "xjcCatalogResolutionGlobal"
 
         private val DefaultXjcToolDependenciesByVersion = mapOf(
+            "2.1" to listOf(        // Supports JAXB -target 2.1  (and 2.0)
+                "com.sun.xml.bind:jaxb-xjc:2.1.17",
+                "com.sun.xml.bind:jaxb-core:2.1.14",
+                "com.sun.xml.bind:jaxb-impl:2.1.17",
+                "javax.xml.bind:jaxb-api:2.1"
+            ),
             "2.2" to listOf(        // Supports JAXB -target 2.2  (and 2.1 and 2.0)
                 "com.sun.xml.bind:jaxb-xjc:2.2.11",
                 "com.sun.xml.bind:jaxb-core:2.2.11",

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
@@ -136,7 +136,7 @@ class XjcPlugin : Plugin<Project> {
                     task.catalogs.setFrom(xjcSourceSetConvention.xjcCatalog)
 
                     task.pluginClasspath.setFrom(xjcClasspathConfiguration)
-                    task.catalogResolutionClasspath.set(catalogResolutionConfiguration)
+                    task.catalogSerializableResolvedArtifact.set(project.provider { XjcGenerate.resolveArtifactsForMavenUri(catalogResolutionConfiguration) })
                     task.episodes.setFrom(episodesConfiguration)
 
                     task.targetPackage.set(xjcSourceSetConvention.xjcTargetPackage)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
@@ -36,7 +36,10 @@ class XjcPlugin : Plugin<Project> {
                 "javax.xml.bind:jaxb-api:2.2.11"
             ),
             "2.3" to listOf(
-                "com.sun.xml.bind:jaxb-xjc:2.3.3"
+                "com.sun.xml.bind:jaxb-xjc:2.3.8",
+                "com.sun.xml.bind:jaxb-core:2.3.0.1", // there is no later 2.3 version
+                "com.sun.xml.bind:jaxb-impl:2.3.8",  // or 2.3.3
+                "javax.xml.bind:jaxb-api:2.3.1"
             ),
             "2.4" to listOf(        // Supports JAXB -target 2.2  (and 2.1 and 2.0)
                 "com.sun.xml.bind:jaxb-xjc:2.4.0-b180830.0438",

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
@@ -38,6 +38,12 @@ class XjcPlugin : Plugin<Project> {
             "2.3" to listOf(
                 "com.sun.xml.bind:jaxb-xjc:2.3.3"
             ),
+            "2.4" to listOf(        // Supports JAXB -target 2.2  (and 2.1 and 2.0)
+                "com.sun.xml.bind:jaxb-xjc:2.4.0-b180830.0438",
+                "com.sun.xml.bind:jaxb-core:2.3.0.1", // there is no 2.4 version
+                "com.sun.xml.bind:jaxb-impl:2.4.0-b180830.0438",
+                "javax.xml.bind:jaxb-api:2.4.0-b180830.0359"
+            ),
             "3.0" to listOf(
                 "com.sun.xml.bind:jaxb-xjc:3.0.2",
                 "com.sun.xml.bind:jaxb-core:3.0.2",

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
@@ -73,6 +73,7 @@ class XjcPlugin : Plugin<Project> {
             (task as XjcGeneratorOptions).setFrom(xjcExtension)
             task.toolClasspath.setFrom(toolClasspathConfiguration)
             task.extraArgs.addAll(xjcExtension.extraArgs)
+            task.xjcVersionUnsupportedStrategy.set(xjcExtension.xjcVersionUnsupportedStrategy)
         }
 
         project.plugins.withType(JavaBasePlugin::class.java) {

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
@@ -33,7 +33,7 @@ class XjcPlugin : Plugin<Project> {
                 "com.sun.xml.bind:jaxb-xjc:2.2.11",
                 "com.sun.xml.bind:jaxb-core:2.2.11",
                 "com.sun.xml.bind:jaxb-impl:2.2.11",
-                "javax.xml.bind:jaxb-api:2.2.11"
+                "javax.xml.bind:jaxb-api:2.2.12"
             ),
             "2.3" to listOf(
                 "com.sun.xml.bind:jaxb-xjc:2.3.8",

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
@@ -39,8 +39,10 @@ class XjcPlugin : Plugin<Project> {
                 "com.sun.xml.bind:jaxb-xjc:2.3.3"
             ),
             "3.0" to listOf(
-                "com.sun.xml.bind:jaxb-xjc:3.0.0-M4",
-                "com.sun.xml.bind:jaxb-impl:3.0.0-M4"
+                "com.sun.xml.bind:jaxb-xjc:3.0.2",
+                "com.sun.xml.bind:jaxb-core:3.0.2",
+                "com.sun.xml.bind:jaxb-impl:3.0.2",
+                "jakarta.xml.bind:jakarta.xml.bind-api:3.0.1"
             )
         )
     }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
@@ -29,13 +29,13 @@ class XjcPlugin : Plugin<Project> {
         val XJC_GLOBAL_CATALOG_RESOLUTION_CONFIGURATION_NAME = "xjcCatalogResolutionGlobal"
 
         private val DefaultXjcToolDependenciesByVersion = mapOf(
-            "2.2" to listOf(
+            "2.2" to listOf(        // Supports JAXB -target 2.2  (and 2.1 and 2.0)
                 "com.sun.xml.bind:jaxb-xjc:2.2.11",
                 "com.sun.xml.bind:jaxb-core:2.2.11",
                 "com.sun.xml.bind:jaxb-impl:2.2.11",
                 "javax.xml.bind:jaxb-api:2.2.12"
             ),
-            "2.3" to listOf(
+            "2.3" to listOf(        // Supports JAXB -target 2.2  (and 2.1 and 2.0)
                 "com.sun.xml.bind:jaxb-xjc:2.3.8",
                 "com.sun.xml.bind:jaxb-core:2.3.0.1", // there is no later 2.3 version
                 "com.sun.xml.bind:jaxb-impl:2.3.8",  // or 2.3.3
@@ -47,7 +47,7 @@ class XjcPlugin : Plugin<Project> {
                 "com.sun.xml.bind:jaxb-impl:2.4.0-b180830.0438",
                 "javax.xml.bind:jaxb-api:2.4.0-b180830.0359"
             ),
-            "3.0" to listOf(
+            "3.0" to listOf(        // Supports JAXB -target 3.0  (and 2.3)
                 "com.sun.xml.bind:jaxb-xjc:3.0.2",
                 "com.sun.xml.bind:jaxb-core:3.0.2",
                 "com.sun.xml.bind:jaxb-impl:3.0.2",

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPlugin.kt
@@ -52,6 +52,12 @@ class XjcPlugin : Plugin<Project> {
                 "com.sun.xml.bind:jaxb-core:3.0.2",
                 "com.sun.xml.bind:jaxb-impl:3.0.2",
                 "jakarta.xml.bind:jakarta.xml.bind-api:3.0.1"
+            ),
+            "4.0" to listOf(        // Supports JAXB -target 3.0  (and 2.3)
+                "com.sun.xml.bind:jaxb-xjc:4.0.2",
+                "com.sun.xml.bind:jaxb-core:4.0.2",
+                "com.sun.xml.bind:jaxb-impl:4.0.2",
+                "jakarta.xml.bind:jakarta.xml.bind-api:4.0.0"
             )
         )
     }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/internal/ManifestUtils.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/internal/ManifestUtils.kt
@@ -11,6 +11,7 @@ internal object ManifestAttributes {
     val MainClass = Attributes.Name("Main-Class")
     val BundleSymbolicName = Attributes.Name("Bundle-SymbolicName")
     val SpecificationVersion = Attributes.Name("Specification-Version")
+    val ExtensionName = Attributes.Name("Extension-Name")
 }
 
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/internal/ProjectProperties.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/internal/ProjectProperties.kt
@@ -2,6 +2,7 @@ package org.unbrokendome.gradle.plugins.xjc.internal
 
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import java.io.Serializable
 
 
 internal fun Project.providerFromProjectProperty(
@@ -20,7 +21,7 @@ internal fun Project.booleanProviderFromProjectProperty(
     )
 
 
-internal fun <T : Any> Project.providerFromProjectProperty(
+internal fun <T : Serializable> Project.providerFromProjectProperty(
     propertyName: String, transform: (String) -> T, defaultValue: T? = null
 ): Provider<T> = provider {
     findProperty(propertyName)?.toString()?.let(transform) ?: defaultValue

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/internal/XjcGeneratorWorkParameters.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/internal/XjcGeneratorWorkParameters.kt
@@ -7,7 +7,6 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.workers.WorkParameters
-import java.util.Locale
 
 
 interface XjcGeneratorWorkParameters : WorkParameters {
@@ -23,7 +22,7 @@ interface XjcGeneratorWorkParameters : WorkParameters {
     val episodes: ConfigurableFileCollection
     val targetPackage: Property<String>
     val encoding: Property<String>
-    val docLocale: Property<Locale>
+    val docLocale: Property<String>
     val episodeTargetFile: RegularFileProperty
     val extraArgs: ListProperty<String>
     val flags: SetProperty<XjcGeneratorFlags>

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/ExtensibleCatalogResolver.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/ExtensibleCatalogResolver.kt
@@ -3,6 +3,9 @@ package org.unbrokendome.gradle.plugins.xjc.resolver
 import org.apache.xml.resolver.CatalogManager
 import org.apache.xml.resolver.tools.CatalogResolver
 import org.slf4j.LoggerFactory
+import org.unbrokendome.gradle.plugins.xjc.resolver.ReflectionHelper.Companion.reflectiveInvoke_URLConnection_getDefaultUseCaches
+import org.unbrokendome.gradle.plugins.xjc.resolver.ReflectionHelper.Companion.reflectiveInvoke_URLConnection_setDefaultUseCaches
+import org.xml.sax.InputSource
 import java.net.URI
 
 
@@ -13,6 +16,43 @@ class ExtensibleCatalogResolver(
 
     companion object {
         private val logger = LoggerFactory.getLogger(ExtensibleCatalogResolver::class.java)
+    }
+
+    override fun resolveEntity(publicId: String?, systemId: String?): InputSource? {
+        val JAR = "jar"
+        // val useCaches = URLConnection.getDefaultUseCaches(JAR)
+        val useCaches = reflectiveInvoke_URLConnection_getDefaultUseCaches(JAR)
+        try {
+            reflectiveInvoke_URLConnection_setDefaultUseCaches(JAR, false)
+            // URLConnection.setDefaultUseCaches(JAR, false)
+
+            logger.debug("resolveEntity({}, {}): lookup", publicId, systemId)
+
+            // Why are we intercepting this?  Well the classpath JAR loader is based on URLConnection
+            // and this has a concept of cacheable entities.  So it attempts to maintain a shared and
+            // open file handle to the containing JAR file even when the last resource InputStream
+            // needing it has been closed.
+            //
+            // The Apache xml-resolver:1.2 implementation always returns an open InputStream for a
+            // successful use of #resolveEnntity(String,String) as per
+            // org.apache.xml.resolver.tools.CatalogResolver#L211
+            //
+            // This causes a problem, as even though Gradle and this plugin manage the XJC classloader
+            // to isolate even when that classloader is closed the JVM still maintains an open file
+            // handle, which is a problem for using Gradle daemon in a long-running way from IDE in
+            // Windows where JAR locking is a headache.
+            val inputSource = super.resolveEntity(publicId, systemId)
+
+            if (inputSource?.byteStream != null)
+                ReflectionHelper.addInputStream(inputSource.byteStream)
+            // inputSource.characterStream // this exists as well but not used
+
+            return inputSource
+        } finally {
+            // URLConnection.setDefaultUseCaches(JAR, useCaches)
+            if(useCaches != null)
+                reflectiveInvoke_URLConnection_setDefaultUseCaches(JAR, useCaches)
+        }
     }
 
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/MavenUriResolver.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/MavenUriResolver.kt
@@ -49,10 +49,12 @@ class MavenUriResolver(
                 matchingArtifacts.map { it.file.toURI().toURL() }.toList().toTypedArray()
             )
             val resourceName = path.removePrefix("/")
-            classLoader.getResource(resourceName)?.toURI()
-                ?: throw IllegalArgumentException(
-                    "Could not resolve resource \"$resourceName\" from classpath: ${classLoader.urLs.toList()}"
-                )
+            classLoader.use {
+                classLoader.getResource(resourceName)?.toURI()
+                    ?: throw IllegalArgumentException(
+                        "Could not resolve resource \"$resourceName\" from classpath: ${classLoader.urLs.toList()}"
+                    )
+            }
 
         } else {
             matchingArtifacts.first()

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/MavenUriResolver.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/MavenUriResolver.kt
@@ -55,6 +55,14 @@ class MavenUriResolver(
             )
             val resourceName = path.removePrefix("/")
             classLoader.use {
+
+                val resList = classLoader.getResources(resourceName).toList()
+                if(resList.size > 1) {
+                    for((index,arti) in artifacts.withIndex()) {
+                        logger.warn("MavenUriResolver multiple matching resources found[{}]: {}", index, arti)
+                    }
+                }
+
                 classLoader.getResource(resourceName)?.toURI()
                     ?: throw IllegalArgumentException(
                         "Could not resolve resource \"$resourceName\" from classpath: ${classLoader.urLs.toList()}"

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/MavenUriResolver.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/MavenUriResolver.kt
@@ -57,8 +57,13 @@ class MavenUriResolver(
             }
 
         } else {
-            matchingArtifacts.first()
-                .file.toURI()
+            val artifacts = matchingArtifacts.toList()
+            if(artifacts.size > 1) {
+                for((index,it) in artifacts.withIndex()) {
+                    logger.warn("MavenUriResolver multiple matching artifacts found, only index 0 is selected[{}]: {}", index, it)
+                }
+            }
+            artifacts[0].file.toURI()
         }
     }
 }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/MavenUriResolver.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/MavenUriResolver.kt
@@ -45,6 +45,11 @@ class MavenUriResolver(
         val path = dependency.path
 
         return if (path != null) {
+            if(logger.isDebugEnabled) {     // This is useful visibility for users
+                matchingArtifacts.forEach {
+                    logger.debug("MavenUriResolver matchingArtifacts={} for {}", it, dependency)
+                }
+            }
             val classLoader = URLClassLoader(
                 matchingArtifacts.map { it.file.toURI().toURL() }.toList().toTypedArray()
             )

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/ReflectionHelper.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/ReflectionHelper.kt
@@ -1,0 +1,114 @@
+package org.unbrokendome.gradle.plugins.xjc.resolver
+
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.io.InputStream
+import java.lang.reflect.InvocationTargetException
+import java.util.concurrent.ConcurrentLinkedQueue
+
+class ReflectionHelper {
+
+    // Trying to keep this ugliness away from the main code
+    companion object {
+        private val logger = LoggerFactory.getLogger(ExtensibleCatalogResolver::class.java)
+
+        private val inputStreams: ConcurrentLinkedQueue<InputStream> = ConcurrentLinkedQueue()
+
+        fun addInputStream(inputStream: InputStream) {
+            inputStreams.add(inputStream)
+        }
+
+        fun closeAll() {
+            if(inputStreams.size > 0)
+                logger.debug("{}#closeAll() count={}", ReflectionHelper::class.java.simpleName, inputStreams.size)
+
+            while (!inputStreams.isEmpty()) {
+                val c = inputStreams.remove()
+
+                try {
+                    c.close()
+                } catch(_: IOException) {
+                }
+
+                try {
+                    if(c.javaClass.name.endsWith("JarURLInputStream")) {
+                        // "sun.net.www.protocol.jar.JarURLConnection$JarURLInputStream"
+                        reflectiveInvoke_jarFile_close(c);
+                    }
+                } catch(_: IOException) {
+                }
+            }
+        }
+
+        private fun reflectiveInvoke_jarFile_close(o: InputStream): Boolean? {
+            // Ugly hacks for broken JRE features
+            try {
+                // Enclosing Class field reference to enclosing instance, name is JavaC convention
+                val enclosingParentField = o.javaClass.getDeclaredField("this$0")
+                enclosingParentField.isAccessible = true
+                val enclosingParentInstance = enclosingParentField.get(o)   // JarURLConnection
+                val klass = enclosingParentInstance.javaClass   // URLJarFile
+                val jarFileField = klass.getDeclaredField("jarFile")
+                jarFileField.isAccessible = true
+                val jarFile = jarFileField.get(enclosingParentInstance)
+                if(jarFile != null) {
+                    val closeMethod = jarFile.javaClass.getMethod("close")
+                    closeMethod.invoke(jarFile)
+                    logger.debug("{}.jarFile.close()", o)
+                    return true
+                }
+                return false
+            } catch(_: NoSuchFieldException) {
+            } catch(_: NoSuchMethodException) {
+            } catch(_: IllegalArgumentException) {
+            } catch(_: IllegalAccessException) {
+            } catch(_: InvocationTargetException) {
+            } catch(_: SecurityException) {
+            } catch(e: Throwable) {
+                // we catch this as the reflection approach is a best-effort and should not
+                //   cause a terminal failure due to an obscure JVM being different here
+                logger.warn("{}", "", e)
+            }
+            return null
+        }
+
+        fun reflectiveInvoke_URLConnection_getDefaultUseCaches(protocol: String): Boolean? {
+            // JDK8 compatibility
+            try {
+                val klass = Class.forName("java.net.URLConnection") // since 1.0
+                val m = klass.getMethod("getDefaultUseCaches", String::class.java)  // JDK9+
+                val rv = m.invoke(null, protocol) as Boolean
+                logger.debug("URLConnection.getDefaultUseCaches({}) = {}", protocol, rv)
+                return rv
+            } catch(_: NoSuchMethodException) {
+            } catch(_: InvocationTargetException) {
+            } catch(_: SecurityException) {
+            } catch(e: Throwable) {
+                // we catch this as the reflection approach is a best-effort and should not
+                //   cause a terminal failure due to an obscure JVM being different here
+                logger.warn("{}", "", e)
+            }
+            return null
+        }
+
+        fun reflectiveInvoke_URLConnection_setDefaultUseCaches(protocol: String, defaultVal: Boolean): Boolean {
+            // JDK8 compatibility
+            try {
+                val klass = Class.forName("java.net.URLConnection") // since 1.0
+                val m = klass.getMethod("setDefaultUseCaches", String::class.java, Boolean::class.java)  // JDK9+
+                m.invoke(null, protocol, defaultVal)
+                logger.debug("URLConnection.setDefaultUseCaches({}, {})", protocol, defaultVal)
+                return true
+            } catch(_: NoSuchMethodException) {
+            } catch(_: InvocationTargetException) {
+            } catch(_: SecurityException) {
+            } catch(e: Throwable) {
+                // we catch this as the reflection approach is a best-effort and should not
+                //   cause a terminal failure due to an obscure JVM being different here
+                logger.warn("{}", "", e)
+            }
+            return false
+        }
+    }
+
+}

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/ReflectionHelper.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/xjc/resolver/ReflectionHelper.kt
@@ -5,6 +5,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.regex.Pattern
 
 class ReflectionHelper {
 
@@ -67,7 +68,10 @@ class ReflectionHelper {
             } catch(e: Throwable) {
                 // we catch this as the reflection approach is a best-effort and should not
                 //   cause a terminal failure due to an obscure JVM being different here
-                logger.warn("{}", "", e)
+                if(logger.isDebugEnabled)
+                    logger.debug("{}", "", e)
+                else if(isJre8OrEarlier())
+                    logger.warn("{}: {}", e.javaClass.name, e.message)
             }
             return null
         }
@@ -86,7 +90,10 @@ class ReflectionHelper {
             } catch(e: Throwable) {
                 // we catch this as the reflection approach is a best-effort and should not
                 //   cause a terminal failure due to an obscure JVM being different here
-                logger.warn("{}", "", e)
+                if(logger.isDebugEnabled)
+                    logger.debug("{}", "", e)
+                else if(isJre8OrEarlier())
+                    logger.warn("{}: {}", e.javaClass.name, e.message)
             }
             return null
         }
@@ -105,9 +112,21 @@ class ReflectionHelper {
             } catch(e: Throwable) {
                 // we catch this as the reflection approach is a best-effort and should not
                 //   cause a terminal failure due to an obscure JVM being different here
-                logger.warn("{}", "", e)
+                if(logger.isDebugEnabled)
+                    logger.debug("{}", "", e)
+                else if(isJre8OrEarlier())
+                    logger.warn("{}: {}", e.javaClass.name, e.message)
             }
             return false
+        }
+
+        private fun isJre8OrEarlier(): Boolean {
+            val sysPropJavaVersion = System.getProperty("java.version")
+            val pattern = Pattern.compile("^\\s*(\\d+).*")
+            val versionMajor = pattern.matcher(sysPropJavaVersion).let {
+                if(it.matches()) Integer.valueOf(it.group(1)) else 0
+            }
+            return versionMajor <= 8
         }
     }
 

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/MaintenanceChangesTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/MaintenanceChangesTest.kt
@@ -1,0 +1,42 @@
+package org.unbrokendome.gradle.plugins.xjc
+
+import org.gradle.internal.impldep.org.testng.Assert.assertEquals
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import org.unbrokendome.gradle.plugins.xjc.XjcSourceSetConvention.Companion.toWords
+
+object MaintenanceChangesTest : Spek({
+
+    describe("org.gradle.util.GUtil deprecation") {
+        it("validate replacement method") {
+            val expected = sequenceOf(
+                "" to "",
+                "a" to "a",
+                "A_Z" to "a z",
+                "oneTwo" to "one two",
+                "A9_Z" to "a9 z",
+                "A_9Z" to "a 9 z",
+                "A\$9Z4" to "a 9 z4",
+                "0A\$9Z4" to "0 a 9 z4",
+                "one9Two" to "one9 two",
+                "UPPERCASE" to "uppercase",
+                "UPPERcase" to "uppe rcase",    // this is what came out of original method
+                "upperCASE" to "upper case",
+                "ABbCddE" to "a bb cdd e",
+                "ABbCDdE" to "a bb c dd e",
+                "AbbCddE" to "abb cdd e",
+                "AbbCdE" to "abb cd e",
+                "AbCdE" to "ab cd e",
+                "abcDefGhi Jkl mnoPqr stu vwx yz" to "abc def ghi jkl mno pqr stu vwx yz",
+                "A\$B?C-D:E.F" to "a b c d e f"
+            )
+
+            expected.forEach {
+                val actual = toWords(it.first)
+                //val actual = org.gradle.util.GUtil.toWords(it.first)
+                assertEquals(actual, it.second, "'${it.first}' to actual '$actual' != '${it.second}' expected")
+            }
+        }
+    }
+
+})

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerateTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerateTest.kt
@@ -54,16 +54,16 @@ object XjcGenerateTest : Spek({
             }
 
             assertThat(task, "task").all {
-                prop(XjcGenerate::targetVersion).hasValueEqualTo("XYZ")
-                prop(XjcGenerate::encoding).hasValueEqualTo("ISO-8859-1")
-                prop(XjcGenerate::docLocale).hasValueEqualTo(Locale.ITALIAN.toString())
-                prop(XjcGenerate::strictCheck).isFalse()
-                prop(XjcGenerate::packageLevelAnnotations).isFalse()
-                prop(XjcGenerate::noFileHeader).isFalse()
-                prop(XjcGenerate::enableIntrospection).isTrue()
-                prop(XjcGenerate::contentForWildcard).isTrue()
-                prop(XjcGenerate::readOnly).isTrue()
-                prop(XjcGenerate::extension).isTrue()
+                this.prop(XjcGenerate::targetVersion).hasValueEqualTo("XYZ")
+                this.prop(XjcGenerate::encoding).hasValueEqualTo("ISO-8859-1")
+                this.prop(XjcGenerate::docLocale).hasValueEqualTo(Locale.ITALIAN.toString())
+                this.prop(XjcGenerate::strictCheck).isFalse()
+                this.prop(XjcGenerate::packageLevelAnnotations).isFalse()
+                this.prop(XjcGenerate::noFileHeader).isFalse()
+                this.prop(XjcGenerate::enableIntrospection).isTrue()
+                this.prop(XjcGenerate::contentForWildcard).isTrue()
+                this.prop(XjcGenerate::readOnly).isTrue()
+                this.prop(XjcGenerate::extension).isTrue()
             }
         }
 
@@ -104,9 +104,9 @@ object XjcGenerateTest : Spek({
 
         it("should create an XjcGenerate task for each existing source set") {
             assertThat(project.tasks, name = "tasks").all {
-                containsItem("xjcGenerate")
+                this.containsItem("xjcGenerate")
                     .isInstanceOf(XjcGenerate::class)
-                containsItem("xjcGenerateTest")
+                this.containsItem("xjcGenerateTest")
                     .isInstanceOf(XjcGenerate::class)
             }
         }
@@ -125,13 +125,13 @@ object XjcGenerateTest : Spek({
             }
 
             assertThat(task, name = "task").all {
-                prop(XjcGenerate::source)
+                this.prop(XjcGenerate::source)
                     .containsOnly(project.file("src/main/schema/schema.xsd"))
-                prop(XjcGenerate::bindingFiles)
+                this.prop(XjcGenerate::bindingFiles)
                     .containsOnly(project.file("src/main/schema/binding.xjb"))
-                prop(XjcGenerate::urlSources)
+                this.prop(XjcGenerate::urlSources)
                     .containsOnly(project.file("src/main/schema/externals.url"))
-                prop(XjcGenerate::catalogs)
+                this.prop(XjcGenerate::catalogs)
                     .containsOnly(project.file("src/main/schema/catalog.cat"))
             }
         }
@@ -148,9 +148,9 @@ object XjcGenerateTest : Spek({
             )
 
             assertThat(task, name = "task").all {
-                prop(XjcGenerate::pluginClasspath)
+                this.prop(XjcGenerate::pluginClasspath)
                     .containsOnly(project.file("custom-jaxb-plugin-1.2.3.jar"))
-                prop(XjcGenerate::episodes)
+                this.prop(XjcGenerate::episodes)
                     .containsOnly(project.file("custom-episode-1.2.3.jar"))
             }
         }
@@ -162,7 +162,7 @@ object XjcGenerateTest : Spek({
             val resolved = XjcGenerate.resolveArtifactsForMavenUri(catalogResolutionConfig)
 
             assertThat(task, name = "task").all {
-                prop(XjcGenerate::catalogSerializableResolvedArtifact)
+                this.prop(XjcGenerate::catalogSerializableResolvedArtifact)
                     .hasValueEqualTo(resolved)
             }
         }
@@ -178,9 +178,9 @@ object XjcGenerateTest : Spek({
             xjcSourceSetConvention.xjcGenerateEpisode.set(true)
 
             assertThat(task, name = "task").all {
-                prop(XjcGenerate::targetPackage)
+                this.prop(XjcGenerate::targetPackage)
                     .hasValueEqualTo("com.example")
-                prop(XjcGenerate::generateEpisode)
+                this.prop(XjcGenerate::generateEpisode)
                     .hasValueEqualTo(true)
             }
         }
@@ -211,9 +211,9 @@ object XjcGenerateTest : Spek({
             val task = project.tasks.getByName("xjcGenerate") as XjcGenerate
 
             assertThat(task, name = "task").all {
-                prop(XjcGenerate::outputDirectory)
+                this.prop(XjcGenerate::outputDirectory)
                     .dirValue().isEqualTo(project.file("build/generated/sources/xjc/java/main"))
-                prop(XjcGenerate::episodeOutputDirectory)
+                this.prop(XjcGenerate::episodeOutputDirectory)
                     .dirValue().isEqualTo(project.file("build/generated/resources/xjc/main"))
             }
         }

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerateTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerateTest.kt
@@ -43,7 +43,7 @@ object XjcGenerateTest : Spek({
             with(project.requiredExtension<XjcExtension>()) {
                 targetVersion.set("XYZ")
                 encoding.set("ISO-8859-1")
-                docLocale.set(Locale.ITALIAN)
+                docLocale.set(Locale.ITALIAN.toString())
                 strictCheck.set(false)
                 packageLevelAnnotations.set(false)
                 noFileHeader.set(false)
@@ -56,7 +56,7 @@ object XjcGenerateTest : Spek({
             assertThat(task, "task").all {
                 prop(XjcGenerate::targetVersion).hasValueEqualTo("XYZ")
                 prop(XjcGenerate::encoding).hasValueEqualTo("ISO-8859-1")
-                prop(XjcGenerate::docLocale).hasValueEqualTo(Locale.ITALIAN)
+                prop(XjcGenerate::docLocale).hasValueEqualTo(Locale.ITALIAN.toString())
                 prop(XjcGenerate::strictCheck).isFalse()
                 prop(XjcGenerate::packageLevelAnnotations).isFalse()
                 prop(XjcGenerate::noFileHeader).isFalse()

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerateTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcGenerateTest.kt
@@ -159,10 +159,11 @@ object XjcGenerateTest : Spek({
         it("should use the catalog resolution classpath") {
             val task = project.tasks.getByName("xjcGenerate") as XjcGenerate
             val catalogResolutionConfig = project.configurations.getByName("xjcCatalogResolution")
+            val resolved = XjcGenerate.resolveArtifactsForMavenUri(catalogResolutionConfig)
 
             assertThat(task, name = "task").all {
-                prop(XjcGenerate::catalogResolutionClasspath)
-                    .hasValueEqualTo(catalogResolutionConfig)
+                prop(XjcGenerate::catalogSerializableResolvedArtifact)
+                    .hasValueEqualTo(resolved)
             }
         }
 

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPluginTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPluginTest.kt
@@ -86,7 +86,7 @@ object XjcPluginTest : Spek({
                     prop(XjcExtension::srcDirName).hasValueEqualTo("xjc")
                     prop(XjcExtension::targetVersion).hasValueEqualTo("2.2")
                     prop(XjcExtension::encoding).hasValueEqualTo("ISO-8859-1")
-                    prop(XjcExtension::docLocale).hasValueEqualTo(Locale.ITALIAN)
+                    prop(XjcExtension::docLocale).hasValueEqualTo(Locale.ITALIAN.toString())
                     prop(XjcExtension::strictCheck).isFalse()
                     prop(XjcExtension::packageLevelAnnotations).isFalse()
                     prop(XjcExtension::noFileHeader).isFalse()

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPluginTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPluginTest.kt
@@ -9,15 +9,9 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSetContainer
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.containsItem
-import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.hasConvention
-import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.hasExtension
-import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.hasValueEqualTo
 import org.unbrokendome.gradle.plugins.xjc.spek.applyPlugin
 import org.unbrokendome.gradle.plugins.xjc.spek.setupGradleProject
-import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.extendsOnlyFrom
-import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.isFalse
-import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.isTrue
+import org.unbrokendome.gradle.plugins.xjc.testutil.assertions.*
 import org.unbrokendome.gradle.plugins.xjc.testutil.evaluate
 import org.unbrokendome.gradle.plugins.xjc.testutil.requiredExtension
 import org.unbrokendome.gradle.plugins.xjc.testutil.sourceSets
@@ -48,17 +42,17 @@ object XjcPluginTest : Spek({
         it("xjc DSL extension should apply defaults") {
             assertThat(project)
                 .hasExtension<XjcExtension>().all {
-                    prop(XjcExtension::xjcVersion).hasValueEqualTo(XjcExtension.DEFAULT_XJC_VERSION)
-                    prop(XjcExtension::xjcVersionUnsupportedStrategy).hasValueEqualTo(XjcExtension.DEFAULT_XJC_VERSION_UNSUPPORTED_STRATEGY)
-                    prop(XjcExtension::srcDirName).hasValueEqualTo(XjcExtension.DEFAULT_SRC_DIR_NAME)
-                    prop(XjcExtension::encoding).hasValueEqualTo("UTF-8")
-                    prop(XjcExtension::strictCheck).isTrue()
-                    prop(XjcExtension::packageLevelAnnotations).isTrue()
-                    prop(XjcExtension::noFileHeader).isTrue()
-                    prop(XjcExtension::enableIntrospection).isFalse()
-                    prop(XjcExtension::contentForWildcard).isFalse()
-                    prop(XjcExtension::readOnly).isFalse()
-                    prop(XjcExtension::extension).isFalse()
+                    this.prop(XjcExtension::xjcVersion).hasValueEqualTo(XjcExtension.DEFAULT_XJC_VERSION)
+                    this.prop(XjcExtension::xjcVersionUnsupportedStrategy).hasValueEqualTo(XjcExtension.DEFAULT_XJC_VERSION_UNSUPPORTED_STRATEGY)
+                    this.prop(XjcExtension::srcDirName).hasValueEqualTo(XjcExtension.DEFAULT_SRC_DIR_NAME)
+                    this.prop(XjcExtension::encoding).hasValueEqualTo("UTF-8")
+                    this.prop(XjcExtension::strictCheck).isTrue()
+                    this.prop(XjcExtension::packageLevelAnnotations).isTrue()
+                    this.prop(XjcExtension::noFileHeader).isTrue()
+                    this.prop(XjcExtension::enableIntrospection).isFalse()
+                    this.prop(XjcExtension::contentForWildcard).isFalse()
+                    this.prop(XjcExtension::readOnly).isFalse()
+                    this.prop(XjcExtension::extension).isFalse()
                 }
         }
 
@@ -81,28 +75,28 @@ object XjcPluginTest : Spek({
 
             assertThat(project)
                 .hasExtension<XjcExtension>().all {
-                    prop(XjcExtension::xjcVersion).hasValueEqualTo("3.0")
-                    prop(XjcExtension::xjcVersionUnsupportedStrategy).hasValueEqualTo("default")
-                    prop(XjcExtension::srcDirName).hasValueEqualTo("xjc")
-                    prop(XjcExtension::targetVersion).hasValueEqualTo("2.2")
-                    prop(XjcExtension::encoding).hasValueEqualTo("ISO-8859-1")
-                    prop(XjcExtension::docLocale).hasValueEqualTo(Locale.ITALIAN.toString())
-                    prop(XjcExtension::strictCheck).isFalse()
-                    prop(XjcExtension::packageLevelAnnotations).isFalse()
-                    prop(XjcExtension::noFileHeader).isFalse()
-                    prop(XjcExtension::enableIntrospection).isTrue()
-                    prop(XjcExtension::contentForWildcard).isTrue()
-                    prop(XjcExtension::readOnly).isTrue()
-                    prop(XjcExtension::extension).isTrue()
+                    this.prop(XjcExtension::xjcVersion).hasValueEqualTo("3.0")
+                    this.prop(XjcExtension::xjcVersionUnsupportedStrategy).hasValueEqualTo("default")
+                    this.prop(XjcExtension::srcDirName).hasValueEqualTo("xjc")
+                    this.prop(XjcExtension::targetVersion).hasValueEqualTo("2.2")
+                    this.prop(XjcExtension::encoding).hasValueEqualTo("ISO-8859-1")
+                    this.prop(XjcExtension::docLocale).hasValueEqualTo(Locale.ITALIAN.toString())
+                    this.prop(XjcExtension::strictCheck).isFalse()
+                    this.prop(XjcExtension::packageLevelAnnotations).isFalse()
+                    this.prop(XjcExtension::noFileHeader).isFalse()
+                    this.prop(XjcExtension::enableIntrospection).isTrue()
+                    this.prop(XjcExtension::contentForWildcard).isTrue()
+                    this.prop(XjcExtension::readOnly).isTrue()
+                    this.prop(XjcExtension::extension).isTrue()
                 }
         }
 
 
         it("should create global XJC configurations") {
             assertThat(project.configurations, "configurations").all {
-                containsItem("xjcTool")
-                containsItem("xjcClasspathGlobal")
-                containsItem("xjcCatalogResolutionGlobal")
+                this.containsItem("xjcTool")
+                this.containsItem("xjcClasspathGlobal")
+                this.containsItem("xjcCatalogResolutionGlobal")
             }
         }
     }
@@ -119,9 +113,9 @@ object XjcPluginTest : Spek({
             val sourceSets = project.extensions.getByType(SourceSetContainer::class.java)
 
             assertThat(sourceSets).all {
-                containsItem("main")
+                this.containsItem("main")
                     .hasConvention<XjcSourceSetConvention>()
-                containsItem("test")
+                this.containsItem("test")
                     .hasConvention<XjcSourceSetConvention>()
             }
         }
@@ -136,17 +130,17 @@ object XjcPluginTest : Spek({
 
         it("should create XJC configurations for each existing source set") {
             assertThat(project.configurations, name = "configurations").all {
-                containsItem("xjcClasspath")
+                this.containsItem("xjcClasspath")
                     .extendsOnlyFrom("xjcClasspathGlobal")
-                containsItem("xjcEpisodes")
-                containsItem("xjcCatalogResolution").all {
+                this.containsItem("xjcEpisodes")
+                this.containsItem("xjcCatalogResolution").all {
                     extendsOnlyFrom("xjcCatalogResolutionGlobal", "compileClasspath")
                 }
 
-                containsItem("testXjcClasspath")
+                this.containsItem("testXjcClasspath")
                     .extendsOnlyFrom("xjcClasspathGlobal")
-                containsItem("testXjcEpisodes")
-                containsItem("testXjcCatalogResolution").all {
+                this.containsItem("testXjcEpisodes")
+                this.containsItem("testXjcCatalogResolution").all {
                     extendsOnlyFrom("xjcCatalogResolutionGlobal", "testCompileClasspath")
                 }
             }
@@ -156,7 +150,7 @@ object XjcPluginTest : Spek({
         it("should create XJC configurations for each new source set") {
             project.sourceSets.create("foo")
             assertThat(project.configurations, name = "configurations").all {
-                containsItem("fooXjcClasspath")
+                this.containsItem("fooXjcClasspath")
                     .extendsOnlyFrom("xjcClasspathGlobal")
             }
         }

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPluginTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcPluginTest.kt
@@ -49,6 +49,7 @@ object XjcPluginTest : Spek({
             assertThat(project)
                 .hasExtension<XjcExtension>().all {
                     prop(XjcExtension::xjcVersion).hasValueEqualTo(XjcExtension.DEFAULT_XJC_VERSION)
+                    prop(XjcExtension::xjcVersionUnsupportedStrategy).hasValueEqualTo(XjcExtension.DEFAULT_XJC_VERSION_UNSUPPORTED_STRATEGY)
                     prop(XjcExtension::srcDirName).hasValueEqualTo(XjcExtension.DEFAULT_SRC_DIR_NAME)
                     prop(XjcExtension::encoding).hasValueEqualTo("UTF-8")
                     prop(XjcExtension::strictCheck).isTrue()
@@ -65,6 +66,7 @@ object XjcPluginTest : Spek({
         it("should populate xjc DSL extension from project properties") {
             val extra = project.requiredExtension<ExtraPropertiesExtension>()
             extra.set("xjc.xjcVersion", "3.0")
+            extra.set("xjc.xjcVersionUnsupportedStrategy", "default")
             extra.set("xjc.srcDirName", "xjc")
             extra.set("xjc.targetVersion", "2.2")
             extra.set("xjc.encoding", "ISO-8859-1")
@@ -80,6 +82,7 @@ object XjcPluginTest : Spek({
             assertThat(project)
                 .hasExtension<XjcExtension>().all {
                     prop(XjcExtension::xjcVersion).hasValueEqualTo("3.0")
+                    prop(XjcExtension::xjcVersionUnsupportedStrategy).hasValueEqualTo("default")
                     prop(XjcExtension::srcDirName).hasValueEqualTo("xjc")
                     prop(XjcExtension::targetVersion).hasValueEqualTo("2.2")
                     prop(XjcExtension::encoding).hasValueEqualTo("ISO-8859-1")

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcSourceSetConventionTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/XjcSourceSetConventionTest.kt
@@ -40,13 +40,13 @@ object XjcSourceSetConventionTest : Spek({
 
         it("should return the correct task and configuration names") {
             assertThat(xjcSourceSetConvention).all {
-                prop(XjcSourceSetConvention::xjcGenerateTaskName)
+                this.prop(XjcSourceSetConvention::xjcGenerateTaskName)
                     .isEqualTo("xjcGenerate")
-                prop(XjcSourceSetConvention::xjcClasspathConfigurationName)
+                this.prop(XjcSourceSetConvention::xjcClasspathConfigurationName)
                     .isEqualTo("xjcClasspath")
-                prop(XjcSourceSetConvention::xjcEpisodesConfigurationName)
+                this.prop(XjcSourceSetConvention::xjcEpisodesConfigurationName)
                     .isEqualTo("xjcEpisodes")
-                prop(XjcSourceSetConvention::xjcCatalogResolutionConfigurationName)
+                this.prop(XjcSourceSetConvention::xjcCatalogResolutionConfigurationName)
                     .isEqualTo("xjcCatalogResolution")
             }
         }
@@ -66,13 +66,13 @@ object XjcSourceSetConventionTest : Spek({
 
         it("should return the correct task and configuration names") {
             assertThat(xjcSourceSetConvention).all {
-                prop(XjcSourceSetConvention::xjcGenerateTaskName)
+                this.prop(XjcSourceSetConvention::xjcGenerateTaskName)
                     .isEqualTo("xjcGenerateCustom")
-                prop(XjcSourceSetConvention::xjcClasspathConfigurationName)
+                this.prop(XjcSourceSetConvention::xjcClasspathConfigurationName)
                     .isEqualTo("customXjcClasspath")
-                prop(XjcSourceSetConvention::xjcEpisodesConfigurationName)
+                this.prop(XjcSourceSetConvention::xjcEpisodesConfigurationName)
                     .isEqualTo("customXjcEpisodes")
-                prop(XjcSourceSetConvention::xjcCatalogResolutionConfigurationName)
+                this.prop(XjcSourceSetConvention::xjcCatalogResolutionConfigurationName)
                     .isEqualTo("customXjcCatalogResolution")
             }
         }
@@ -80,13 +80,13 @@ object XjcSourceSetConventionTest : Spek({
 
         it("should set default include filters") {
             assertThat(xjcSourceSetConvention).all {
-                prop("xjcSchema") { it.xjcSchema }
+                this.prop("xjcSchema") { it.xjcSchema }
                     .prop("includes") { it.includes }
                     .containsOnly("**/*.xsd")
-                prop("xjcBinding") { it.xjcBinding }
+                this.prop("xjcBinding") { it.xjcBinding }
                     .prop("includes") { it.includes }
                     .containsOnly("**/*.xjb")
-                prop("xjcUrl") { it.xjcUrl }
+                this.prop("xjcUrl") { it.xjcUrl }
                     .prop("includes") { it.includes }
                     .containsOnly("**/*.url")
             }
@@ -98,13 +98,13 @@ object XjcSourceSetConventionTest : Spek({
             xjc.srcDirName.set("xjc")
 
             assertThat(xjcSourceSetConvention).all {
-                prop("xjcSchema") { it.xjcSchema }
+                this.prop("xjcSchema") { it.xjcSchema }
                     .prop("srcDirs") { it.srcDirs }
                     .containsOnly(project.file("src/custom/xjc"))
-                prop("xjcBinding") { it.xjcBinding }
+                this.prop("xjcBinding") { it.xjcBinding }
                     .prop("srcDirs") { it.srcDirs }
                     .containsOnly(project.file("src/custom/xjc"))
-                prop("xjcUrl") { it.xjcUrl }
+                this.prop("xjcUrl") { it.xjcUrl }
                     .prop("srcDirs") { it.srcDirs }
                     .containsOnly(project.file("src/custom/xjc"))
             }

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/Configuration.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/Configuration.kt
@@ -10,7 +10,7 @@ import org.gradle.api.artifacts.Configuration
 
 fun Assert<Configuration>.extendsFrom(other: String) = given { actual ->
     if (other in actual.extendsFrom.map { it.name }) return
-    expected(
+    this.expected(
         "to extend from configuration \"$other\", but extends from: ${show(actual.extendsFrom)}",
         actual = actual.extendsFrom, expected = other
     )
@@ -21,7 +21,7 @@ fun Assert<Configuration>.extendsOnlyFrom(vararg others: String) = given { actua
     val extendsFromNames = actual.extendsFrom.map { it.name }.toSet()
     if (others.toSet() == extendsFromNames) return
 
-    expected(
+    this.expected(
         "to extend only from configuration(s) ${show(others)}, but extends from: ${show(extendsFromNames)}",
         actual = extendsFromNames, expected = others
     )

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/Container.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/Container.kt
@@ -8,13 +8,13 @@ import org.gradle.api.NamedDomainObjectCollection
 
 fun <T : Any> Assert<NamedDomainObjectCollection<T>>.containsItem(name: String) =
     transform(name = "${this.name}[\"$name\"]") { actual ->
-        actual.findByName(name) ?: expected("to contain an item named \"$name\"", actual = actual.names)
+        actual.findByName(name) ?: this.expected("to contain an item named \"$name\"", actual = actual.names)
     }
 
 
 fun <T : Any> Assert<NamedDomainObjectCollection<T>>.doesNotContainItem(name: String) = given { actual ->
     val item = actual.findByName(name)
     if (item != null) {
-        expected("to contain no item named \"$name\", but did contain: ${show(item)}", actual = actual.names)
+        this.expected("to contain no item named \"$name\", but did contain: ${show(item)}", actual = actual.names)
     }
 }

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/Extension.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/Extension.kt
@@ -11,32 +11,32 @@ import kotlin.reflect.KClass
 fun Assert<Any>.hasExtensionNamed(name: String): Assert<Any> =
     transform("extension \"$name\"") { actual ->
         if (actual !is ExtensionAware) {
-            expected("to be ExtensionAware")
+            this.expected("to be ExtensionAware")
         }
         actual.extensions.findByName(name)
-            ?: expected("to have an extension named \"$name\"")
+            ?: this.expected("to have an extension named \"$name\"")
     }
 
 
 inline fun <reified E : Any> Assert<Any>.hasExtension(name: String? = null): Assert<E> =
     transform("extension " + (name?.let { "\"$it\"" } ?: show(E::class))) { actual ->
         if (actual !is ExtensionAware) {
-            expected("to be ExtensionAware")
+            this.expected("to be ExtensionAware")
         }
         val extensions = actual.extensions
 
         if (name != null) {
             val extension = extensions.findByName(name)
-                ?: expected("to have an extension named \"$name\" of type ${show(E::class)}")
+                ?: this.expected("to have an extension named \"$name\" of type ${show(E::class)}")
             (extension as? E)
-                ?: expected(
+                ?: this.expected(
                     "to have an extension named \"$name\" of type ${show(E::class)}, " +
                             "but actual type was: ${show(extension.javaClass)}"
                 )
 
         } else {
             extensions.findByType(E::class.java)
-                ?: expected("to have an extension of type ${show(E::class)}")
+                ?: this.expected("to have an extension of type ${show(E::class)}")
         }
     }
 
@@ -44,12 +44,12 @@ inline fun <reified E : Any> Assert<Any>.hasExtension(name: String? = null): Ass
 fun <C : Any> Assert<Any>.hasConvention(type: KClass<C>): Assert<C> =
     transform("convention ${show(type)}") { actual ->
         if (actual !is HasConvention) {
-            expected("to support conventions")
+            this.expected("to support conventions")
         }
         actual.convention.findPlugin(type.java)
-            ?: expected("to have a convention plugin of type ${show(type)}")
+            ?: this.expected("to have a convention plugin of type ${show(type)}")
     }
 
 
 inline fun <reified C : Any> Assert<Any>.hasConvention(): Assert<C> =
-    hasConvention(C::class)
+    this.hasConvention(C::class)

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/GradleProject.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/GradleProject.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.KClass
 private fun Assert<Project>.containsTaskInternal(taskName: String) =
     transform("task \"$taskName\"") { actual ->
         actual.tasks.findByName(taskName)
-            ?: expected("to contain a task named \"$taskName\"")
+            ?: this.expected("to contain a task named \"$taskName\"")
     }
 
 
@@ -21,4 +21,4 @@ fun <T : Task> Assert<Project>.containsTask(taskName: String, taskType: KClass<T
 
 
 inline fun <reified T : Task> Assert<Project>.containsTask(taskName: String) =
-    containsTask(taskName, T::class)
+    this.containsTask(taskName, T::class)

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/GradleTask.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/GradleTask.kt
@@ -18,7 +18,7 @@ val Assert<Task>.taskDependencies
 fun Assert<Task>.hasTaskDependency(taskName: String) = given { actual ->
     val dependencies = actual.taskDependencies.getDependencies(actual)
     if (dependencies.none { it.name == taskName }) {
-        expected("to have a dependency on task \"${taskName}\", but dependencies were: ${show(dependencies)}")
+        this.expected("to have a dependency on task \"${taskName}\", but dependencies were: ${show(dependencies)}")
     }
 }
 
@@ -26,7 +26,7 @@ fun Assert<Task>.hasTaskDependency(taskName: String) = given { actual ->
 fun Assert<Task>.hasOnlyTaskDependency(taskName: String) = given { actual ->
     val dependencies = actual.taskDependencies.getDependencies(actual)
     if (dependencies.size != 1 || dependencies.firstOrNull()?.name != taskName) {
-        expected("to have a single dependency on task \"${taskName}\", but dependencies were: ${show(dependencies)}")
+        this.expected("to have a single dependency on task \"${taskName}\", but dependencies were: ${show(dependencies)}")
     }
 }
 
@@ -49,20 +49,20 @@ fun Assert<Task>.hasTaskDependencies(vararg taskNames: String, exactly: Boolean 
 fun Assert<Task>.doesNotHaveTaskDependency(taskName: String) = given { actual ->
     val dependencies = actual.taskDependencies.getDependencies(actual)
     if (dependencies.any { it.name == taskName }) {
-        expected("to have no dependency on task \"${taskName}\", but dependencies were: ${show(dependencies)}")
+        this.expected("to have no dependency on task \"${taskName}\", but dependencies were: ${show(dependencies)}")
     }
 }
 
 
 fun Assert<Task>.isSkipped() = given { actual ->
     if (!actual.isSkipped()) {
-        expected("to be skipped, but was not skipped")
+        this.expected("to be skipped, but was not skipped")
     }
 }
 
 
 fun Assert<Task>.isNotSkipped() = given { actual ->
     if (actual.isSkipped()) {
-        expected("not to be skipped, but was skipped")
+        this.expected("not to be skipped, but was skipped")
     }
 }

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/Provider.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/xjc/testutil/assertions/Provider.kt
@@ -14,31 +14,31 @@ import org.gradle.api.provider.Provider
 
 
 fun <T : Any?> Assert<Provider<T>>.isPresent() = transform { actual ->
-    actual.orNull ?: expected("${show(actual)} to have a value", actual = actual)
+    actual.orNull ?: this.expected("${show(actual)} to have a value", actual = actual)
 }
 
 
 fun Assert<Provider<Boolean>>.isTrue() =
-    isPresent().isTrue()
+    this.isPresent().isTrue()
 
 
 fun Assert<Provider<Boolean>>.isFalse() =
-    isPresent().isFalse()
+    this.isPresent().isFalse()
 
 
 fun <T : Any?> Assert<Provider<T>>.hasValueEqualTo(value: T) =
-    isPresent().isEqualTo(value)
+    this.isPresent().isEqualTo(value)
 
 
 fun Assert<Provider<RegularFile>>.fileValue() =
-    isPresent()
+    this.isPresent()
         .prop("file") { it.asFile }
 
 
 fun Assert<Provider<Directory>>.dirValue() =
-    isPresent()
+    this.isPresent()
         .prop("directory") { it.asFile }
 
 
 fun <K : Any, V : Any> Assert<Provider<Map<K, V>>>.contains(key: K, value: V) =
-    isPresent().contains(key, value)
+    this.isPresent().contains(key, value)

--- a/src/xjc21/kotlin/org/unbrokendome/gradle/plugins/xjc/work/xjc21/XjcGeneratorLegacyWorkAction.kt
+++ b/src/xjc21/kotlin/org/unbrokendome/gradle/plugins/xjc/work/xjc21/XjcGeneratorLegacyWorkAction.kt
@@ -1,0 +1,16 @@
+package org.unbrokendome.gradle.plugins.xjc.work.xjc21
+
+import com.sun.tools.xjc.Options
+import org.unbrokendome.gradle.plugins.xjc.work.common.*
+import javax.inject.Inject
+
+
+@Suppress("unused") // instantiated dynamically
+abstract class XjcGeneratorLegacyWorkAction
+@Inject constructor(): AbstractXjcGeneratorWorkAction() {
+
+    override fun getContextClassLoaderHolder(): IContextClassLoaderHolder = ContextClassLoaderHolderV21()
+
+    override fun getOptionsAccessor(options: Options): IOptionsAccessor = OptionsAccessorV21(options)
+
+}

--- a/src/xjc24/kotlin/org/unbrokendome/gradle/plugins/xjc/work/xjc24/XjcGeneratorWorkAction.kt
+++ b/src/xjc24/kotlin/org/unbrokendome/gradle/plugins/xjc/work/xjc24/XjcGeneratorWorkAction.kt
@@ -1,0 +1,8 @@
+package org.unbrokendome.gradle.plugins.xjc.work.xjc24
+
+import org.unbrokendome.gradle.plugins.xjc.work.common.AbstractXjcGeneratorWorkAction
+import javax.inject.Inject
+
+@Suppress("unused") // instantiated dynamically
+abstract class XjcGeneratorWorkAction
+@Inject constructor(): AbstractXjcGeneratorWorkAction()

--- a/src/xjc40/kotlin/org/unbrokendome/gradle/plugins/xjc/work/xjc40/XjcGeneratorWorkAction.kt
+++ b/src/xjc40/kotlin/org/unbrokendome/gradle/plugins/xjc/work/xjc40/XjcGeneratorWorkAction.kt
@@ -1,0 +1,8 @@
+package org.unbrokendome.gradle.plugins.xjc.work.xjc40
+
+import org.unbrokendome.gradle.plugins.xjc.work.common.AbstractXjcGeneratorWorkAction
+import javax.inject.Inject
+
+@Suppress("unused") // instantiated dynamically
+abstract class XjcGeneratorWorkAction
+@Inject constructor(): AbstractXjcGeneratorWorkAction()

--- a/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/AbstractXjcGeneratorWorkAction.kt
+++ b/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/AbstractXjcGeneratorWorkAction.kt
@@ -17,6 +17,7 @@ import org.unbrokendome.gradle.plugins.xjc.resolver.MavenUriResolver
 import org.xml.sax.InputSource
 import java.net.URI
 import java.net.URISyntaxException
+import java.util.Locale
 
 
 abstract class AbstractXjcGeneratorWorkAction : WorkAction<XjcGeneratorWorkParameters> {
@@ -32,7 +33,7 @@ abstract class AbstractXjcGeneratorWorkAction : WorkAction<XjcGeneratorWorkParam
 
         val docLocale = parameters.docLocale.orNull
         if (docLocale != null) {
-            withDefaultLocale(docLocale) {
+            withDefaultLocale(Locale.forLanguageTag(docLocale)) {
                 doExecute(options)
             }
         } else {

--- a/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/ContextClassLoaderHolder.kt
+++ b/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/ContextClassLoaderHolder.kt
@@ -1,0 +1,33 @@
+package org.unbrokendome.gradle.plugins.xjc.work.common
+
+import com.sun.tools.xjc.Options
+import java.io.Closeable
+import java.io.IOException
+
+class ContextClassLoaderHolder : IContextClassLoaderHolder {
+    private var contextClassLoader: ClassLoader? = null
+
+    override fun setup(options: Options) {
+        // Set up the classloader containing the plugin classpath. This should happen before any call
+        // to parseArgument() or parseArguments() because it might trigger the resolution of plugins
+        // (which are then cached)
+        contextClassLoader = Thread.currentThread().contextClassLoader
+        var userClassLoader = options.getUserClassLoader(contextClassLoader) as ClassLoader
+        Thread.currentThread().contextClassLoader = userClassLoader
+    }
+
+    override fun restore() {
+        if(contextClassLoader != null) {
+            val userClassLoader = Thread.currentThread().contextClassLoader
+            Thread.currentThread().contextClassLoader = contextClassLoader
+            if(userClassLoader != contextClassLoader && userClassLoader is Closeable) {
+                try {
+                    userClassLoader.close()
+                } catch(_: IOException) {
+                }
+            }
+            contextClassLoader = null
+        }
+    }
+
+}

--- a/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/ContextClassLoaderHolderV21.kt
+++ b/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/ContextClassLoaderHolderV21.kt
@@ -1,0 +1,37 @@
+package org.unbrokendome.gradle.plugins.xjc.work.common
+
+import com.sun.tools.xjc.Options
+import java.io.Closeable
+import java.io.IOException
+import java.net.URLClassLoader
+
+class ContextClassLoaderHolderV21 : IContextClassLoaderHolder {
+    private var contextClassLoader: ClassLoader? = null
+
+    override fun setup(options: Options) {
+        // Set up the classloader containing the plugin classpath. This should happen before any call
+        // to parseArgument() or parseArguments() because it might trigger the resolution of plugins
+        // (which are then cached)
+        contextClassLoader = Thread.currentThread().contextClassLoader
+        var userClassLoader = contextClassLoader
+        if(!options.classpaths.isEmpty())
+            userClassLoader = URLClassLoader(options.classpaths.toTypedArray(), contextClassLoader);
+        //var userClassLoader = options.getUserClassLoader(contextClassLoader)
+        Thread.currentThread().contextClassLoader = userClassLoader
+    }
+
+    override fun restore() {
+        if(contextClassLoader != null) {
+            val userClassLoader = Thread.currentThread().contextClassLoader
+            Thread.currentThread().contextClassLoader = contextClassLoader
+            if(userClassLoader != contextClassLoader && userClassLoader is Closeable) {
+                try {
+                    userClassLoader.close()
+                } catch(_: IOException) {
+                }
+            }
+            contextClassLoader = null
+        }
+    }
+
+}

--- a/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/IContextClassLoaderHolder.kt
+++ b/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/IContextClassLoaderHolder.kt
@@ -1,0 +1,11 @@
+package org.unbrokendome.gradle.plugins.xjc.work.common
+
+import com.sun.tools.xjc.Options
+
+interface IContextClassLoaderHolder {
+
+    fun restore()
+
+    fun setup(options: Options)
+
+}

--- a/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/IOptionsAccessor.kt
+++ b/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/IOptionsAccessor.kt
@@ -1,0 +1,11 @@
+package org.unbrokendome.gradle.plugins.xjc.work.common
+
+interface IOptionsAccessor {
+
+    fun hasEncoding(): Boolean
+
+    fun getEncoding(): String?
+
+    fun setEncoding(encoding: String?): Unit
+
+}

--- a/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/OptionsAccessor.kt
+++ b/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/OptionsAccessor.kt
@@ -1,0 +1,18 @@
+package org.unbrokendome.gradle.plugins.xjc.work.common
+
+import com.sun.tools.xjc.Options
+
+// XJC Options v2.2+ through 4.0.x (the latest at this time)
+class OptionsAccessor(options: Options) : IOptionsAccessor {
+
+    private val options = options
+
+    override fun hasEncoding() = true
+
+    override fun getEncoding(): String? = options.encoding
+
+    override fun setEncoding(encoding: String?) {
+        options.encoding = encoding
+    }
+
+}

--- a/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/OptionsAccessorV21.kt
+++ b/src/xjcCommon/kotlin/org/unbrokendome/gradle/plugins/xjc/work/common/OptionsAccessorV21.kt
@@ -1,0 +1,18 @@
+package org.unbrokendome.gradle.plugins.xjc.work.common
+
+import com.sun.tools.xjc.Options
+
+// XJC Options v2.1
+class OptionsAccessorV21(options: Options) : IOptionsAccessor {
+
+    private val options = options
+
+    override fun hasEncoding() = false
+
+    override fun getEncoding(): String? = null
+
+    override fun setEncoding(encoding: String?) {
+        // NOOP
+    }
+
+}


### PR DESCRIPTION
Update on https://github.com/unbroken-dome/gradle-xjc-plugin/pull/47

As per my comment https://github.com/unbroken-dome/gradle-xjc-plugin/pull/47#issuecomment-1848797444  this is a reopened using a separate source branch at the origin repo.

   Main features:
         * JDK21 and Gradle 8.5 tested
         * Configuration Cache compatible (thanks Ryan Dens)
         * Removal of deprecated APIs (marked for removal in Gradle 9)
            #51 org.gradle.util.GUtil

This was also released today as 2.2.0 over at the origin repo.